### PR TITLE
Fix for The Hobit Draft Game's "Narya"

### DIFF
--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/unofficial/hobbit/set32/set32-fp.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/unofficial/hobbit/set32/set32-fp.hjson
@@ -812,10 +812,11 @@
   }
   32_23: {
     title: Narya
-		unique: true
+    unique: true
     culture: gandalf
     twilight: 0
     type: artifact
+    itemclass: ring
     vitality: 1
     target: name(Gandalf)
     effects: [


### PR DESCRIPTION
Should be classified as a Ring