### PR TITLE
Adjusting Game Timers

### DIFF
--- a/gemp-lotr/gemp-lotr-async/src/main/web/hall.html
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/hall.html
@@ -246,10 +246,10 @@
 			<select id="supportedFormatsSelect" ></select>
 			<select id="decksSelect" ></select>
 			<select id="timerSelect">
-				<option value="default">Default (80m/5m)</option>
-				<option value="blitz">Blitz! (30m/5m)</option>
-				<option value="slow">Slow (2h/10m)</option>
-				<option value="glacial">Glacial (3d/1d)</option>
+				<option value="default">Default (45m/6m)</option>
+				<option value="blitz">Blitz! (25m/3m)</option>
+				<option value="slow">Slow (80m/10m)</option>
+				<option value="glacial">Glacial (1d/1d)</option>
 			</select>
 			<input id='tableDescInput' type='text' maxlength='100' placeHolder='Description (or player to invite)'>
 			<div class="checkboxes">

--- a/gemp-lotr/gemp-lotr-async/src/main/web/includes/admin/leagueAdmin.html
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/includes/admin/leagueAdmin.html
@@ -503,9 +503,9 @@ function leagueErrorMap(outputControl, callback=null) {
 				<option value="Competitive">Competitive (40/5)</option>
 				<option value="WC">Championship (20/10)</option>
 				<option value="WC_Expanded">Championship Expanded (25/10)</option>
-				<option value="Blitz!">Blitz (30/5)</option>
-				<option value="Default">Default (80/5)</option>
-				<option value="Slow">Slow (120/10)</option>
+				<option value="Blitz!">Blitz (25/3)</option>
+				<option value="Default">Default (45/6)</option>
+				<option value="Slow">Slow (80/10)</option>
 			</select><br/>
 		<div class="tablesgroup">
 			<div class="tabledata">

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/GameTimer.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/GameTimer.java
@@ -2,10 +2,10 @@ package com.gempukku.lotro.hall;
 
 public record GameTimer(boolean longGame, String name, int maxSecondsPerPlayer, int maxSecondsPerDecision) {
 
-    public static final GameTimer DEFAULT_TIMER = new GameTimer(false, "Default", 60 * 80, 60 * 5);
-    public static final GameTimer BLITZ_TIMER = new GameTimer(false, "Blitz!", 60 * 30, 60 * 5);
-    public static final GameTimer SLOW_TIMER = new GameTimer(false, "Slow", 60 * 120, 60 * 10);
-    public static final GameTimer GLACIAL_TIMER = new GameTimer(true, "Glacial", 60 * 60 * 24 * 3, 60 * 60 * 24);
+    public static final GameTimer DEFAULT_TIMER = new GameTimer(false, "Default", 60 * 45, 60 * 6);
+    public static final GameTimer BLITZ_TIMER = new GameTimer(false, "Blitz!", 60 * 25, 60 * 3);
+    public static final GameTimer SLOW_TIMER = new GameTimer(false, "Slow", 60 * 80, 60 * 10);
+    public static final GameTimer GLACIAL_TIMER = new GameTimer(true, "Glacial", 60 * 60 * 24, 60 * 60 * 24);
     // 5 minutes timeout, 40 minutes per game per player
     public static final GameTimer COMPETITIVE_TIMER = new GameTimer(false, "Competitive", 60 * 40, 60 * 5);
     public static final GameTimer CHAMPIONSHIP_TIMER = new GameTimer(false, "WC", 60 * 20, 60 * 10);


### PR DESCRIPTION
A step in the right direction towards game timers that reflect the reasons players are choosing them. These should be reviewed in the future once we've got some sort of metric to compare the times against -- % of games that run out of time, for example, or some analysis on predicting a rage quit vs a temporary disconnect vs a hard turn to think through. I suspect that, with the possible exception of the default decision timer, these times are still quite generous.