### PR TITLE
Adding auto-zoom

### DIFF
--- a/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/autozoom.css
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/autozoom.css
@@ -1,0 +1,17 @@
+
+.previewImage {
+    position: absolute;
+    z-index: 1099;
+    pointer-events: none;
+    
+}
+
+.previewImage, .previewImage img,
+.card, .card img  {
+    border-radius: 5%;
+}
+
+
+
+
+

--- a/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/deckBuild.css
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/deckBuild.css
@@ -105,24 +105,16 @@ button.navigation-butt {
     padding: 0;
 }
 
-button.navigation-butt {
-    padding: 0.5em;
-}
-
-.navigation-butt.ui-button-icon-only > .ui-button-text{
-    padding: 0;
-}
-
-.navigation-butt.ui-button-icon-only {
-    width:  25px;
-}
-
 .ui-button-icon-only .ui-button-icon-primary.ui-icon {
     margin:  auto auto auto -4px;
 }
 
 #culture-buttons .ui-button {
     padding: 0;
+}
+
+#collectionSelect {
+    order:  99;
 }
 
 #collectionSelect {
@@ -140,6 +132,11 @@ button.navigation-butt {
 
 .notesDialog {
     display: flex;
+}
+
+#auto-zoom-toggle {
+    width: 27px;
+    height: 23px;
 }
 
 

--- a/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/game.css
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/game.css
@@ -439,3 +439,36 @@ body {
     font-size: 3rem; 
     transform:translateY(30%);
 }
+
+.previewImage {
+    position: absolute;
+    z-index: 1099;
+    pointer-events: none;
+    
+}
+
+.previewImage, .previewImage img,
+.card, .card img  {
+    border-radius: 5%;
+}
+
+#auto-zoom-li {
+    float: right;
+}
+
+#auto-zoom-toggle {
+    width: 25px;
+    height: 20px;
+    padding: 0px;
+    margin-top:-5px;
+    margin-right: -5px;
+}
+
+.ui-button-icon-primary.ui-icon.ui-icon-search,
+.ui-button-icon-primary.ui-icon.ui-icon-circle-close {
+    margin-left:4px;
+}
+
+ul.ui-tabs-nav {
+    height: 14px;
+}

--- a/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/game.css
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/game.css
@@ -440,20 +440,12 @@ body {
     transform:translateY(30%);
 }
 
-.previewImage {
-    position: absolute;
-    z-index: 1099;
-    pointer-events: none;
-    
-}
-
-.previewImage, .previewImage img,
-.card, .card img  {
-    border-radius: 5%;
-}
-
 #auto-zoom-li {
     float: right;
+}
+
+ul.ui-tabs-nav {
+    height: 14px;
 }
 
 #auto-zoom-toggle {
@@ -467,8 +459,4 @@ body {
 .ui-button-icon-primary.ui-icon.ui-icon-search,
 .ui-button-icon-primary.ui-icon.ui-icon-circle-close {
     margin-left:4px;
-}
-
-ul.ui-tabs-nav {
-    height: 14px;
 }

--- a/gemp-lotr/gemp-lotr-async/src/main/web/deckBuild.html
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/deckBuild.html
@@ -11,6 +11,7 @@
 	<link rel="manifest" href="images/icons/site.webmanifest">
 
 	<link rel="stylesheet" type="text/css" href="css/gemp-001/deckBuild.css">
+	<link rel="stylesheet" type="text/css" href="css/gemp-001/autozoom.css">
 
 	<link rel="stylesheet" type="text/css" href="css/dark-hive/jquery-ui-1.8.16.custom.css">
 	<link rel="stylesheet" type="text/css" href="css/jquery.contextMenu.css">
@@ -44,6 +45,7 @@
 	<script type="text/javascript" src="js/gemp-022/statsUi.js"></script>
 	<script type="text/javascript" src="js/gemp-022/playerStatsUi.js"></script>
 	<script type="text/javascript" src="js/gemp-022/gameHistoryUi.js"></script>
+	<script type="text/javascript" src="js/gemp-022/AutoZoomHandler.js"></script>
 	<script type="text/javascript" src="js/gemp-022/deckBuildingUi.js"></script>
 	<script type="text/javascript" src="js/gemp-022/gameUi.js"></script>
 	<script type="text/javascript" src="js/gemp-022/gameAnimations.js"></script>

--- a/gemp-lotr/gemp-lotr-async/src/main/web/game.html
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/game.html
@@ -10,6 +10,7 @@
     <link rel="manifest" href="images/icons/site.webmanifest">
 
     <link rel="stylesheet" type="text/css" href="css/gemp-001/game.css">
+    <link rel="stylesheet" type="text/css" href="css/gemp-001/autozoom.css">
 
     <link rel="stylesheet" type="text/css" href="css/dark-hive/jquery-ui-1.8.16.custom.css">
     <link rel="stylesheet" type="text/css" href="css/jquery.contextMenu.css">

--- a/gemp-lotr/gemp-lotr-async/src/main/web/game.html
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/game.html
@@ -44,6 +44,7 @@
     <script type="text/javascript" src="js/gemp-022/playerStatsUi.js"></script>
     <script type="text/javascript" src="js/gemp-022/gameHistoryUi.js"></script>
     <script type="text/javascript" src="js/gemp-022/deckBuildingUi.js"></script>
+    <script type="text/javascript" src="js/gemp-022/AutoZoomHandler.js"></script>
     <script type="text/javascript" src="js/gemp-022/gameUi.js"></script>
     <script type="text/javascript" src="js/gemp-022/gameAnimations.js"></script>
     <script type="text/javascript" src="js/gemp-022/merchantUi.js"></script>

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/autoZoomHandler.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/autoZoomHandler.js
@@ -1,0 +1,268 @@
+class AutoZoom {
+	showPreviewImage = true;
+	previewImageBPID = 0;
+	cookieName = null;
+	
+	isTouchDevice = false;
+	
+	autoZoomToggle = null;
+	previewImageDiv = null;
+	previewImage = null;
+
+	constructor(cookieName) {
+		const that = this;
+		this.cookieName = cookieName;
+		this.isTouchDevice = 'ontouchstart' in document.documentElement;
+		const cookie = $.cookie(this.cookieName);
+		
+		//An unset cookie should default to true.
+		if(cookie == "false") {
+			this.showPreviewImage = false;
+		}
+		else {
+			this.showPreviewImage = true;
+		}
+		
+		if(!this.isTouchDevice) {
+			this._setupToggleButton();
+		}
+
+		this.previewImageDiv = $('<div>', {
+			id: 'previewImage',
+			class: 'previewImage',
+			style: ""
+		}).appendTo('body');
+		this.previewImageDiv.append("<img></img>")
+		this.previewImage = this.previewImageDiv.find("img")[0];
+		
+		this.previewImageDiv = this.previewImageDiv[0];		
+	}
+	
+	_setupToggleButton() {
+		const that = this;
+		const enabledIcon = "ui-icon-search";
+		const disabledIcon = "ui-icon-circle-close";
+		
+		const startingIcon = this.showPreviewImage ? enabledIcon : disabledIcon;
+		
+		this.autoZoomToggle = $("<button id='auto-zoom-toggle'>Auto-zoom cards on hover</button>").button(
+		{
+			icons:{
+				primary:startingIcon
+			}, 
+			text:false
+		});
+		
+		this.autoZoomToggle.click(
+			function () {
+				if (that.showPreviewImage) {
+					that.autoZoomToggle.button("option", "icons", {primary:disabledIcon});
+					that.showPreviewImage = false;
+					that.saveCookieValue();
+				} else {
+					that.autoZoomToggle.button("option", "icons", {primary:enabledIcon});
+					that.showPreviewImage = true;
+					that.saveCookieValue();
+				}
+			});
+		
+		var selected = $("#previewImageOnHover").prop("checked");
+	}
+	
+	saveCookieValue() {
+		$.cookie(this.cookieName, "" + this.showPreviewImage, { expires: 365 });
+	}
+	
+	// make the preview image shown be the reference image that's hovered on:
+	displayPreviewImage(refImageDiv) {
+	
+		const that = this;
+		
+		this.previewImage.onload = function () {
+			
+			that.previewImage.style.display = "block";
+			
+			// get position and size of the reference image (actually the parent div):
+			var rect = refImageDiv.getBoundingClientRect();
+			var srcImageX = rect.left;
+			var srcImageY = rect.top;
+			var srcImageWidth = rect.right - rect.left;
+			var srcImageHeight = rect.bottom - rect.top;
+			// get the size of the browser window:
+			var windowWidth = window.innerWidth;
+			var windowHeight = window.innerHeight;
+			// get the elements to be altered:
+			var previewImageStyle = that.previewImageDiv.style;
+			var previewImageImgStyle = that.previewImage.style;
+			var previewImageHeight = that.previewImage.naturalHeight;
+			var previewImageWidth = that.previewImage.naturalWidth;
+			
+			var ratio = previewImageWidth / previewImageHeight;
+
+			if (previewImageHeight > windowHeight / 2) {
+				previewImageHeight = windowHeight / 2;
+				previewImageWidth = ratio * previewImageHeight;
+			}
+			else if (previewImageWidth > windowWidth / 2) {
+				previewImageWidth = windowWidth / 2;
+				previewImageHeight = previewImageWidth / ratio;
+			}
+
+			// set the horizontal position of the preview image:
+			const rightEdge = srcImageX + srcImageWidth;
+			const leftEdge = srcImageX;
+			const goesPastRightBound = rightEdge + previewImageWidth > windowWidth;
+			const goesPastLeftBound = leftEdge - previewImageWidth < 0;
+			var previewImageLeft = rightEdge;
+			
+			if (goesPastRightBound && goesPastLeftBound) {
+				// if previewImage would extend past either left or right side
+				// of screen, display the previewImage in the biggest space 
+				// available and shrink to fit
+				const rightSpace = windowWidth - (leftEdge + srcImageWidth);
+				const leftSpace = leftEdge;
+				if (rightSpace > leftSpace) {
+					previewImageWidth = rightSpace;
+					previewImageLeft = rightEdge;
+				}
+				else {
+					previewImageWidth = leftSpace;
+					previewImageLeft = leftEdge - previewImageWidth;
+				}
+				previewImageHeight = previewImageWidth / ratio;
+			}
+			else {
+				if (goesPastRightBound) {
+					previewImageLeft = leftEdge - previewImageWidth;
+				}
+				else if (goesPastLeftBound) {
+					previewImageLeft = rightEdge;
+				}
+			}
+
+			// set the vertical position of the preview image (and make sure it isn't extending over the edge of the window):
+			var previewImageTop = (srcImageY + (srcImageHeight / 2)) - (previewImageHeight / 2);
+			if ((previewImageTop + previewImageHeight) > windowHeight) {
+				previewImageTop = windowHeight - previewImageHeight;
+			}
+			else if (previewImageTop < 0) {
+				previewImageTop = 0;
+			}
+
+			// assign the positions to the preview image element:
+			previewImageStyle.left = previewImageLeft + "px";
+			previewImageStyle.top = previewImageTop + "px";
+			previewImageImgStyle.width = previewImageWidth + 'px';
+			previewImageImgStyle.height = previewImageHeight + 'px';
+		}
+		
+		let cardImage = Card.getImageUrl(this.previewImageBPID);
+
+		if (cardImage != null) {
+			this.previewImage.src = cardImage;
+		}
+	}
+
+	hidePreviewImage() {
+		this.previewImageBPID = "0";
+		this.previewImage.src = "";
+		this.previewImage.style.display = "none";
+	}
+
+	rotatePreviewImage(shouldRotate) {
+		var previewImageStyle = this.previewImage.style;
+		if (!shouldRotate) {
+			previewImageStyle.transform = "rotate(0deg)";
+		}
+		else {
+			previewImageStyle.transform = "rotate(180deg)";
+		}
+	}
+
+	handleMouseOver(event, isDragging, infoDialogOpen) {
+		const target = $(event.target);
+		const tarIsCard = target.hasClass("actionArea");
+		
+		// if mouse over target is a card on table, and client supports image previews, showImage
+		if(this.isTouchDevice || !this.showPreviewImage
+		   || !tarIsCard || isDragging || infoDialogOpen) {
+			
+			// if previewImage is active and either the event target isn't a card 
+			// on table OR the user shift+clicked to bring up the card detail 
+			// dialogue, we need to hide the current previewImage
+			if (this.previewImageBPID !== "0" && !tarIsCard) {
+				this.hidePreviewImage();
+				event.stopPropagation();
+				return false;
+			}
+			
+			return true;
+		}
+
+		
+		const refCard = target.closest(".card");
+		const refCardDiv = refCard[0];
+		const card = refCard.data("card");
+		
+		// don't show preview image if card is animating
+		if (!$(refCardDiv).hasClass('card-animating')) {
+			const startFlipped = event.shiftKey;
+			const blueprintId = card.blueprintId;
+			const reverseSideImage = Card.getImageUrl(blueprintId + "_BACK");
+			const imageBlueprintId = startFlipped && reverseSideImage ? blueprintId + "_BACK" : blueprintId;
+
+			// don't show preview image if hovered card is the DS/LS card back art
+			if (imageBlueprintId !== "-1_1" && imageBlueprintId !== "-1_2") {
+				this.previewImageBPID = imageBlueprintId;
+				this.displayPreviewImage(refCardDiv);
+
+				if (!reverseSideImage) {
+					// set the starting rotation based on if shift key
+					// is active when event was triggered, as long as the
+					// card doesn't have a reverse side
+					this.rotatePreviewImage(startFlipped);
+				}
+				
+				event.stopPropagation();
+				return false;
+			}
+		}
+	}
+	
+	handleMouseDown(event) {
+		if (this.previewImageBPID !== 0) {
+			this.hidePreviewImage();
+		}
+	}
+	
+	handleKeyDown(event) {
+		if (this.showPreviewImage && !this.isTouchDevice 
+				&& event.which === 16 && this.previewImageBPID != "0") {
+			const reverseSideImage = Card.getImageUrl(this.previewImageBPID + "_BACK");
+		
+			if (reverseSideImage) {
+				this.previewImageBPID = this.previewImageBPID + "_BACK";
+				this.previewImage.src = reverseSideImage;
+			} 
+			else {
+				this.rotatePreviewImage(true)
+			}
+		};
+		return true;
+	}
+	
+	handleKeyUp(event) {
+		if (this.showPreviewImage && !this.isTouchDevice 
+				&& event.which === 16 && this.previewImageBPID != "0") {
+			const isBackImage = this.previewImageBPID.endsWith('_BACK');
+			if (isBackImage) {
+				this.previewImageBPID = this.previewImageBPID.substring(0, this.previewImageBPID.length - 5);
+				this.previewImage.src = Card.getImageUrl(this.previewImageBPID);
+			} else {
+				this.rotatePreviewImage(false)
+			}
+		};
+		return true;
+	}
+	
+}

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/deckBuildingUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/deckBuildingUi.js
@@ -56,6 +56,8 @@ var GempLotrDeckBuildingUI = Class.extend({
     collectionType:null,
 
     specialSelection:false,
+    
+    autoZoom: null,
 
     init:function () {
         var that = this;
@@ -102,6 +104,8 @@ var GempLotrDeckBuildingUI = Class.extend({
                         that.setMapVisibility(false);
                     }
                 });
+        
+        this.autoZoom = new AutoZoom("autoZoomInDeckbuilder");
 
         var collectionSelect = $("#collectionSelect");
 
@@ -120,6 +124,10 @@ var GempLotrDeckBuildingUI = Class.extend({
         var deckListBut = $("#deckListBut").button();
         
         var notesBut = $("#notesBut").button();
+        
+        if(this.autoZoom.autoZoomToggle != null) {
+            this.autoZoom.autoZoomToggle.appendTo(this.manageDecksDiv);
+        }
 
         this.deckNameSpan = ("#editingDeck");
 
@@ -261,14 +269,38 @@ var GempLotrDeckBuildingUI = Class.extend({
                 }
                 return true;
             });
+        $('body').unbind('mouseover');
+        $("body").mouseover(
+            function (event) {
+                return that.autoZoom.handleMouseOver(event, 
+                   that.dragCardId != null, that.infoDialog.dialog("isOpen"));
+            });
+
         $("body").mousedown(
                 function (event) {
+                    that.autoZoom.handleMouseDown(event);
+                    
                     return that.dragStartCardFunction(event);
                 });
         $("body").mouseup(
                 function (event) {
                     return that.dragStopCardFunction(event);
                 });
+        
+        //If we ever add double-sided cards, this will be needed for
+        // the card hover.
+        
+        $('body').unbind('keydown');
+        $("body").keydown(
+            function (event) {
+                return that.autoZoom.handleKeyDown(event);
+            });
+
+        $('body').unbind('keyup');
+        $("body").keyup(
+            function (event) {
+                return that.autoZoom.handleKeyUp(event);
+            });
 
         var width = $(window).width();
         var height = $(window).height();

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/gameAnimations.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/gameAnimations.js
@@ -69,6 +69,8 @@ var GameAnimations = Class.extend({
 
                         var cardHeight = (gameHeight / 2);
                         var cardWidth = card.getWidthForHeight(cardHeight);
+                        
+                        that.handleCardAnimatedStart(cardDiv);
 
                         $(cardDiv).css(
                             {
@@ -156,6 +158,8 @@ var GameAnimations = Class.extend({
                                     shadowStartPosX = $(targetCard).position().left;
                                     shadowStartPosY = $(targetCard).position().top;
                                 }
+                                
+                                that.handleCardAnimatedStart(cardDiv);
 
                                 $(cardDiv).css(
                                     {
@@ -189,6 +193,8 @@ var GameAnimations = Class.extend({
                                 var cardData = $(this).data("card");
                                 if (cardData.zone == "ANIMATION") {
                                     $(this).remove();
+                                } else {
+                                    that.handleCardAnimatedEnd(this);
                                 }
                             }
                         );
@@ -273,6 +279,8 @@ var GameAnimations = Class.extend({
 
                     var cardHeight = (gameHeight / 2);
                     var cardWidth = card.getWidthForHeight(cardHeight);
+                    
+                    that.handleCardAnimatedStart(cardDiv);
 
                     $(cardDiv).css(
                         {
@@ -286,7 +294,8 @@ var GameAnimations = Class.extend({
 
                     $(cardDiv).animate(
                         {
-                            opacity:1},
+                            opacity:1
+                        },
                         {
                             duration:that.getAnimationLength(that.putCardIntoPlayDuration / 8),
                             easing:"linear",
@@ -297,7 +306,8 @@ var GameAnimations = Class.extend({
                                     cardWidth / 2 + now * (cardWidth / 2),
                                     cardHeight / 2 + now * (cardHeight / 2), 100);
                             },
-                            complete:next});
+                            complete:next
+                        });
                 }).queue(
                 function (next) {
                     setTimeout(next, that.getAnimationLength(that.putCardIntoPlayDuration * (5 / 8)));
@@ -330,6 +340,7 @@ var GameAnimations = Class.extend({
                 function (next) {
                     var cardDiv = $(".card:cardId(" + cardId + ")");
                     $(cardDiv).css({zIndex:oldValues["zIndex"]});
+                    that.handleCardAnimatedEnd(cardDiv);
                     next();
                 });
         }
@@ -395,7 +406,9 @@ var GameAnimations = Class.extend({
         if (animate && (this.game.spectatorMode || this.game.replayMode || (participantId != this.game.bottomPlayerId))) {
             $("#main").queue(
                 function (next) {
-                    $(".card:cardId(" + cardRemovedIds + ")")
+                    const cardDiv = $(".card:cardId(" + cardRemovedIds + ")");
+                    that.handleCardAnimatedStart(cardDiv);
+                    cardDiv
                         .animate(
                         {
                             opacity:0},
@@ -952,5 +965,13 @@ var GameAnimations = Class.extend({
                 that.game.layoutUI(true);
                 next();
             });
+    },
+
+    handleCardAnimatedStart: function (cardDiv) {
+        cardDiv && cardDiv[0] && $(cardDiv[0]).addClass('card-animating')
+    },
+
+    handleCardAnimatedEnd: function (cardDiv) {
+        cardDiv && cardDiv[0] && $(cardDiv[0]).removeClass('card-animating')
     }
 });

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/jCards.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/jCards.js
@@ -204,21 +204,21 @@ var packBlueprints = {
     "SHELBI - Treebeard Starter":"/gemp-lotr/images/boosters/shelbi-treebeard.jpg"
 };
 
-var Card = Class.extend({
-    blueprintId: null,
-    foil: null,
-    tengwar: null,
-    hasWiki: null,
-    horizontal: null,
-    imageUrl: null,
-    zone: null,
-    cardId: null,
-    owner: null,
-    siteNumber: null,
-    attachedCards: null,
-    errata: null,
+class Card {
+    blueprintId = null;
+    foil = null;
+    tengwar = null;
+    hasWiki = null;
+    horizontal = null;
+    imageUrl = null;
+    zone = null;
+    cardId = null;
+    owner = null;
+    siteNumber = null;
+    attachedCards = null;
+    errata = null;
 
-    init: function (blueprintId, zone, cardId, owner, siteNumber) {
+    constructor(blueprintId, zone, cardId, owner, siteNumber) {
         this.blueprintId = blueprintId;
 
         var imageBlueprint = blueprintId;
@@ -233,7 +233,7 @@ var Card = Class.extend({
         if (this.tengwar)
             bareBlueprint = bareBlueprint.substring(0, len - 1);
 
-        this.hasWiki = this.getFixedImage(imageBlueprint) == null
+        this.hasWiki = Card.getFixedImage(imageBlueprint) == null
             && packBlueprints[imageBlueprint] == null;
 
         this.zone = zone;
@@ -251,14 +251,14 @@ var Card = Class.extend({
                 this.imageUrl = cardFromCache.imageUrl;
                 this.errata = cardFromCache.errata;
             } else {
-                this.imageUrl = this.getUrlByBlueprintId(bareBlueprint);
-                this.horizontal = this.isHorizontal(bareBlueprint);
+                this.imageUrl = Card.getImageUrl(bareBlueprint, this.tengwar);
+                this.horizontal = Card.isHorizontal(bareBlueprint);
 
                 var separator = bareBlueprint.indexOf("_");
                 var setNo = parseInt(bareBlueprint.substr(0, separator));
                 var cardNo = parseInt(bareBlueprint.substr(separator + 1));
 
-                this.errata = this.getErrata(setNo, cardNo) != null;
+                this.errata = Card.getErrata(setNo, cardNo) != null;
                 cardCache[imageBlueprint] = {
                     imageUrl: this.imageUrl,
                     horizontal: this.horizontal,
@@ -266,9 +266,9 @@ var Card = Class.extend({
                 };
             }
         }
-    },
-
-    getFixedImage: function (blueprintId) {
+    }
+    
+    static getFixedImage (blueprintId) {
         var img = fixedImages[blueprintId];
         if (img != null)
             return img;
@@ -282,17 +282,17 @@ var Card = Class.extend({
         if (img != null)
             return img;
         return null;
-    },
+    }
 
-    isTengwar: function () {
+    isTengwar() {
         return this.tengwar;
-    },
+    }
 
-    isFoil: function () {
+    isFoil() {
         return this.foil;
-    },
+    }
 
-    hasErrata: function () {
+    hasErrata() {
         var separator = this.blueprintId.indexOf("_");
         var setNo = parseInt(this.blueprintId.substr(0, separator));
         
@@ -300,13 +300,13 @@ var Card = Class.extend({
             return true;
         
         return this.errata;
-    },
+    }
 
-    isPack: function () {
+    isPack() {
         return packBlueprints[this.blueprintId] != null;
-    },
+    }
 
-    isHorizontal: function (blueprintId) {
+    static isHorizontal(blueprintId) {
         var separator = blueprintId.indexOf("_");
         var setNo = parseInt(blueprintId.substr(0, separator));
         var cardNo = parseInt(blueprintId.substr(separator + 1));
@@ -361,11 +361,12 @@ var Card = Class.extend({
             return (cardNo >= 57 && cardNo <= 64);
 
         return false;
-    },
+    }
 
-    getUrlByBlueprintId: function (blueprintId, ignoreErrata) {
-        if (this.getFixedImage(blueprintId) != null)
-            return this.getFixedImage(blueprintId);
+    static getImageUrl(blueprintId, tengwar, ignoreErrata) {
+        let image = Card.getFixedImage(blueprintId)
+        if (image != null)
+            return image;
 
         if (packBlueprints[blueprintId] != null)
             return packBlueprints[blueprintId];
@@ -382,36 +383,36 @@ var Card = Class.extend({
 
         var cardStr;
 
-        if (this.isMasterworks(setNo, cardNo))
-            cardStr = this.formatSetNo(setNo) + "O0" + (cardNo - this.getMasterworksOffset(setNo));
+        if (Card.isMasterworks(setNo, cardNo))
+            cardStr = Card.formatSetNo(setNo) + "O0" + (cardNo - this.getMasterworksOffset(setNo));
         else
-            cardStr = this.formatCardNo(setNo, cardNo);
+            cardStr = Card.formatCardNo(setNo, cardNo);
 
-        return mainLocation + "LOTR" + cardStr + (this.isTengwar() ? "T" : "") + ".jpg";
-    },
+        return mainLocation + "LOTR" + cardStr + (tengwar ? "T" : "") + ".jpg";
+    }
 
-    getWikiLink: function () {
-        var imageUrl = this.getUrlByBlueprintId(this.blueprintId, true);
+    getWikiLink() {
+        var imageUrl = Card.getImageUrl(this.blueprintId, false, true);
         var afterLastSlash = imageUrl.lastIndexOf("/") + 1;
         var countAfterLastSlash = imageUrl.length - 4 - afterLastSlash;
         return "http://wiki.lotrtcgpc.net/wiki/" + imageUrl.substr(afterLastSlash, countAfterLastSlash);
-    },
+    }
 
-    hasWikiInfo: function () {
+    hasWikiInfo() {
         return this.hasWiki;
-    },
+    }
 
-    formatSetNo: function (setNo) {
+    static formatSetNo(setNo) {
         var setNoStr;
         if (setNo < 10)
             setNoStr = "0" + setNo;
         else
             setNoStr = setNo;
         return setNoStr;
-    },
+    }
 
-    formatCardNo: function (setNo, cardNo) {
-        var setNoStr = this.formatSetNo(setNo);
+    static formatCardNo(setNo, cardNo) {
+        var setNoStr = Card.formatSetNo(setNo);
 
         var cardStr;
         if (cardNo < 10)
@@ -422,21 +423,21 @@ var Card = Class.extend({
             cardStr = setNoStr + "" + cardNo;
 
         return cardStr;
-    },
+    }
 
-    getMainLocation: function (setNo, cardNo) {
+    static getMainLocation(setNo, cardNo) {
         return "https://i.lotrtcgpc.net/decipher/";
-    },
+    }
 
-    getMasterworksOffset: function (setNo) {
+    static getMasterworksOffset(setNo) {
         if (setNo == 17)
             return 148;
         if (setNo == 18)
             return 140;
         return 194;
-    },
+    }
 
-    isMasterworks: function (setNo, cardNo) {
+    static isMasterworks(setNo, cardNo) {
         if (setNo == 12)
             return cardNo > 194;
         if (setNo == 13)
@@ -448,9 +449,9 @@ var Card = Class.extend({
         if (setNo == 18)
             return cardNo > 140;
         return false;
-    },
+    }
 
-    remadeErratas: {
+    static remadeErratas = {
         "0": [7],
         "1": [3, 12, 43, 46, 55, 109, 113, 138, 162, 211, 235, 263, 309, 318, 331, 338, 343, 360],
         "3": [48, 110],
@@ -460,35 +461,35 @@ var Card = Class.extend({
         "8": [20, 33, 69],
         "17": [15, 87, 96, 118],
         "18": [8, 12, 20, 25, 35, 48, 50, 55, 77, 78, 79, 80, 82, 94, 97, 133]
-    },
+    }
 
-    getErrata: function (setNo, cardNo) {
-        if (this.remadeErratas["" + setNo] != null && $.inArray(cardNo, this.remadeErratas["" + setNo]) != -1)
-            return "/gemp-lotr/images/erratas/LOTR" + this.formatCardNo(setNo, cardNo) + ".jpg";
+    static getErrata(setNo, cardNo) {
+        if (this.remadeErratas["" + setNo] != null && $.inArray(cardNo, Card.remadeErratas["" + setNo]) != -1)
+            return "/gemp-lotr/images/erratas/LOTR" + Card.formatCardNo(setNo, cardNo) + ".jpg";
         return null;
-    },
+    }
 
-    getHeightForWidth: function (width) {
+    getHeightForWidth(width) {
         if (this.horizontal)
             return Math.floor(width * cardScale);
         else
             return Math.floor(width / cardScale);
-    },
+    }
 
-    getWidthForHeight: function (height) {
+    getWidthForHeight(height) {
         if (this.horizontal)
             return Math.floor(height / cardScale);
         else
             return Math.floor(height * cardScale);
-    },
+    }
 
-    getWidthForMaxDimension: function (maxDimension) {
+    getWidthForMaxDimension(maxDimension) {
         if (this.horizontal)
             return maxDimension;
         else
             return Math.floor(maxDimension * cardScale);
     }
-});
+}
 
 function createCardDiv(image, text, foil, tokens, noBorder, errata) {
     var cardDiv = $("<div class='card'><img src='" + image + "' width='100%' height='100%'>" + ((text != null) ? text : "") + "</div>");


### PR DESCRIPTION
Adds auto-zoom for the game and deckbuilder screens.  This is a way to quickly see all the cards on the field or in the deckbuilder without needing to click on each one.  Also adds a toggle button for disabling the feature on each of those screens.