### PR TITLE
Initial attempt at jetsam

### DIFF
--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/unofficial/pc/setV02/setv02-Gandalf-playtest.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/unofficial/pc/setV02/setv02-Gandalf-playtest.hjson
@@ -25,17 +25,26 @@
 			Pipeweed
 			Support Area
 		]
-		/*requires: {
-			
+		effects: {
+			type: trigger
+			optional: true
+			trigger: {
+				type: played
+				filter: self
+			}
+			effect: [
+				{
+					type: shuffleCardsFromDiscardIntoDrawDeck
+					filter: choose(pipe)
+					count: 0-1
+				}
+				{
+					type: shuffleCardsFromDiscardIntoDrawDeck
+					filter: choose(pipeweed)
+					count: 0-1
+				}
+			]
 		}
-		effects: [
-			{
-				
-			}
-			{
-				
-			}
-		]*/
 		gametext: Pipeweed.<br>When you play this possession, you may shuffle a pipe and a pipeweed into your deck from your discard pile. 
 		lore: "'How it came here, I can't imagine. For Saruman's private use, I fancy.'"
 		promotext: ""

--- a/gemp-lotr/gemp-lotr-server/src/test/java/com/gempukku/lotro/cards/unofficial/pc/vsets/set_v02/Card_V2_012_Tests.java
+++ b/gemp-lotr/gemp-lotr-server/src/test/java/com/gempukku/lotro/cards/unofficial/pc/vsets/set_v02/Card_V2_012_Tests.java
@@ -18,7 +18,11 @@ public class Card_V2_012_Tests
 		return new GenericCardTestHelper(
 				new HashMap<>()
 				{{
-					put("card", "102_12");
+					put("jetsam", "102_12");
+					put("pipe", "1_285");
+					put("pipeweed", "1_305");
+					put("pipe2", "1_285");
+					put("pipeweed2", "1_305");
 					// put other cards in here as needed for the test case
 				}},
 				GenericCardTestHelper.FellowshipSites,
@@ -45,31 +49,67 @@ public class Card_V2_012_Tests
 
 		var scn = GetScenario();
 
-		var card = scn.GetFreepsCard("card");
+		var jetsam = scn.GetFreepsCard("jetsam");
 
-		assertEquals("Jetsam", card.getBlueprint().getTitle());
-		assertNull(card.getBlueprint().getSubtitle());
-		assertFalse(card.getBlueprint().isUnique());
-		assertEquals(Side.FREE_PEOPLE, card.getBlueprint().getSide());
-		assertEquals(Culture.GANDALF, card.getBlueprint().getCulture());
-		assertEquals(CardType.POSSESSION, card.getBlueprint().getCardType());
-		assertTrue(scn.HasKeyword(card, Keyword.PIPEWEED));
-		assertTrue(scn.HasKeyword(card, Keyword.SUPPORT_AREA));
-		assertEquals(1, card.getBlueprint().getTwilightCost());
+		assertEquals("Jetsam", jetsam.getBlueprint().getTitle());
+		assertNull(jetsam.getBlueprint().getSubtitle());
+		assertFalse(jetsam.getBlueprint().isUnique());
+		assertEquals(Side.FREE_PEOPLE, jetsam.getBlueprint().getSide());
+		assertEquals(Culture.GANDALF, jetsam.getBlueprint().getCulture());
+		assertEquals(CardType.POSSESSION, jetsam.getBlueprint().getCardType());
+		assertTrue(scn.HasKeyword(jetsam, Keyword.PIPEWEED));
+		assertTrue(scn.HasKeyword(jetsam, Keyword.SUPPORT_AREA));
+		assertEquals(1, jetsam.getBlueprint().getTwilightCost());
 	}
 
-	// Uncomment any @Test markers below once this is ready to be used
-	//@Test
+	@Test
 	public void JetsamTest1() throws DecisionResultInvalidException, CardNotFoundException {
 		//Pre-game setup
 		var scn = GetScenario();
 
-		var card = scn.GetFreepsCard("card");
-		scn.FreepsMoveCardToHand(card);
+		var jetsam = scn.GetFreepsCard("jetsam");
+		var pipe = scn.GetFreepsCard("pipe");
+		var pipeweed = scn.GetFreepsCard("pipeweed");
+		// var pipe2 = scn.GetFreepsCard("pipe2");
+		// var pipeweed2 = scn.GetFreepsCard("pipeweed2");
+
+		scn.FreepsMoveCardToHand(jetsam);
+		scn.FreepsMoveCardToDiscard(pipe);
+		scn.FreepsMoveCardToDiscard(pipeweed);
 
 		scn.StartGame();
-		scn.FreepsPlayCard(card);
 
+
+		assertEquals(2, scn.GetFreepsDeckCount());
+		assertEquals(2, scn.GetFreepsDiscardCount());
+		assertEquals(0, scn.GetTwilight());
+
+
+		scn.FreepsPlayCard(jetsam);
+
+
+		assertTrue(scn.FreepsHasOptionalTriggerAvailable());
+		scn.FreepsAcceptOptionalTrigger();
+
+		assertTrue(scn.FreepsDecisionAvailable(""));
+		assertEquals(1, scn.GetFreepsCardChoiceCount());
+		assertEquals(Zone.DISCARD, pipe.getZone());
+
+		scn.FreepsChooseCardIDFromSelection(pipe);
+
+		assertEquals(Zone.DECK, pipe.getZone());
+
+
+		assertEquals(1, scn.GetFreepsCardChoiceCount());
+
+		scn.FreepsChooseCardIDFromSelection(pipeweed);
+
+		assertFalse(scn.FreepsHasOptionalTriggerAvailable());
+
+		scn.FreepsPassCurrentPhaseAction();
+
+		assertEquals(4, scn.GetFreepsDeckCount());
+		assertEquals(0, scn.GetFreepsDiscardCount());
 		assertEquals(1, scn.GetTwilight());
 	}
 }


### PR DESCRIPTION
This is not yet ready to merge but I do seem to be stuck on progress for this card and would be happy for a second set of eyes to take a look. 

Basing the hjson off of similar cards, I think it's close to correct but have been having a hard time getting tests to work as I'd expect. 

If I filter to just possession it seems to correctly identify all possessions in my discard as optional targets but filtering to `pipe(weed)` or `pipe(weed),possession` results in no selectable cards. In all cases, I've failed to get the tests to actually put the selected cards back in the draw deck. 

I'm happy to take advise or to jump into a pairing call to look over some of the options that might make this work as expected. 