### PR TITLE
Cost resolving validation and failure mitigation

### DIFF
--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set02/set02-Shire.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set02/set02-Shire.hjson
@@ -659,43 +659,40 @@
 					}
 					memorize: exertCount
 				}
-				
-			]
-			effect: {
-				type: CostToEffect
-				cost: {
+				{
 					type: exert
 					select: memory(weaponBearer)
 					times: {
 						type: fromMemory
 						memory: exertCount
 					}
+					ignoreCostCheckFailure: true
 				}
-				effect: {
-					type: choice
-					texts: [
-						Wound X Orcs
-						Wound X Uruk-hai
-					]
-					effects: [
-						{
-							type: wound
-							select: choose(orc)
-							count: {
-								type: fromMemory
-								memory: exertCount
-							}
+			]
+			effect: {
+				type: choice
+				texts: [
+					Wound X Orcs
+					Wound X Uruk-hai
+				]
+				effects: [
+					{
+						type: wound
+						select: choose(orc)
+						count: {
+							type: fromMemory
+							memory: exertCount
 						}
-						{
-							type: wound
-							select: choose(uruk_hai)
-							count: {
-								type: fromMemory
-								memory: exertCount
-							}
+					}
+					{
+						type: wound
+						select: choose(uruk_hai)
+						count: {
+							type: fromMemory
+							memory: exertCount
 						}
-					]
-				}
+					}
+				]
 			}
 		}
 		gametext: <b>Maneuver:</b> Spot Sting or Glamdring and exert its bearer X times to wound X Orcs or X Uruk-hai.

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set04/set04-Elven.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set04/set04-Elven.hjson
@@ -1037,11 +1037,10 @@
 			trigger: {
 				type: winsSkirmish
 				filter: elf
-				memorize: winner
 			}
 			cost: {
 				type: exert
-				select: memory(winner)
+				select: choose(skirmishWinner)
 			},
 			effect: [
 				{

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set04/set04-Elven.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set04/set04-Elven.hjson
@@ -1036,10 +1036,12 @@
 			trigger: {
 				type: winsSkirmish
 				filter: elf
+				memorize: winner
 			}
 			cost: {
 				type: exert
-				select: choose(skirmishWinner)
+				select: memory(winner)
+				ignoreCostCheckFailure: true
 			},
 			effect: [
 				{

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set06/set06-Gollum.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set06/set06-Gollum.hjson
@@ -286,13 +286,14 @@
 			cost: [
 				{
 					type: exert
-					select: choose(name(Sméagol))
+					select: choose(name(Sméagol),canBeDiscarded)
 					times: 3
 					memorize: smeagol
 				}
 				{
 					type: discard
 					select: memory(smeagol)
+					ignoreCostCheckFailure: true
 				}
 			]
 			effect: [

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set06/set06-Rohan.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set06/set06-Rohan.hjson
@@ -88,6 +88,7 @@
 					{
 						type: discard
 						select: memory(chosenMount)
+						ignoreCostCheckFailure: true
 					}
 				]
 				effect: {

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set07/set07-Dwarven.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set07/set07-Dwarven.hjson
@@ -489,6 +489,7 @@
 							cost: {
 								type: exert
 								select: memory(chosenDwarf)
+								ignoreCostCheckFailure: true
 							}
 							effect: {
 								type: drawCards

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set07/set07-Gandalf.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set07/set07-Gandalf.hjson
@@ -182,11 +182,10 @@
 				trigger: {
 					type: winsSkirmish
 					filter: name(Gandalf)
-					memorize: winner
 				}
 				cost: {
 					type: exert
-					select: memory(winner)
+					select: choose(skirmishWinner)
 				}
 				effect: {
 					type: drawCards
@@ -1009,6 +1008,7 @@
 					type: exert
 					select: choose(name(Gandalf))
 					times: memory(exertCount)
+					ignoreCostCheckFailure: true
 				}
 			]
 			effect: [

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set07/set07-Gandalf.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set07/set07-Gandalf.hjson
@@ -182,10 +182,12 @@
 				trigger: {
 					type: winsSkirmish
 					filter: name(Gandalf)
+					memorize: winner
 				}
 				cost: {
 					type: exert
-					select: choose(skirmishWinner)
+					select: memory(winner)
+					ignoreCostCheckFailure: true
 				}
 				effect: {
 					type: drawCards

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set08/set08-Sauron.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set08/set08-Sauron.hjson
@@ -609,6 +609,7 @@
 						culture: sauron
 						count: memory(tokenCount)
 						select: self
+						ignoreCostCheckFailure: true
 					}
 				]
 				effect: [

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set09/set09-Rohan.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set09/set09-Rohan.hjson
@@ -86,6 +86,7 @@
 						cost: {
 							type: exert
 							select: memory(playedRohanMan)
+							ignoreCostCheckFailure: true
 						}
 						effect: {
 							type: PlayCardFromHand

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set11/set11-Gondor.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set11/set11-Gondor.hjson
@@ -367,6 +367,7 @@
 				{
 					type: exert
 					select: memory(chosenCompanions)
+					ignoreCostCheckFailure: true
 				}
 			]
 			effect: [

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set15/set15-Gandalf.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set15/set15-Gandalf.hjson
@@ -41,6 +41,7 @@
 					type: exert
 					select: memory(chosenCompanion)
 					times: memory(exertCount)
+					ignoreCostCheckFailure: true
 				}
 			]
 			effect: [

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set17/set17-Men.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set17/set17-Men.hjson
@@ -355,6 +355,7 @@
 						cost: {
 							type: discard
 							select: memory(spottedPossession)
+							ignoreCostCheckFailure: true
 						}
 						effect: {
 							type: addKeyword

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/unofficial/pc/errata/set08/set08-Sauron-errata.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/unofficial/pc/errata/set08/set08-Sauron-errata.hjson
@@ -54,6 +54,7 @@
 						type: RemoveCultureTokens
 						select: self
 						count: memory(numberOfTokens)
+						ignoreCostCheckFailure: true
 					}
 					{
 						type: discard

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/unofficial/pc/setV02/V2-Moria.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/unofficial/pc/setV02/V2-Moria.hjson
@@ -304,19 +304,18 @@
 			type: event
 			cost: [
 				{
-					type: ChooseANumber
-					text: Choose how many {moria} minions to discard
-					from: 0
-					to: {
-						type: ForEachYouCanSpot
-						filter: culture(moria), minion
-					}
-					memorize: discardedMinions
+					type: Discard
+					select: choose(culture(Moria),minion)
+					count: any
+					memorize: discardedCards
 				}
 				{
-					type: Discard
-					select: choose(culture(Moria), minion)
-					count: memory(discardedMinions)
+				    type: memorizeNumber
+				    amount: {
+				        type: forEachInMemory
+				        memory: discardedCards
+				    }
+				    memory: discardedMinions
 				}
 			]
 			effect: {
@@ -334,6 +333,7 @@
 						type: Exert
 						select: choose(companion)
 						count: memory(discardedMinions)
+						ignoreCostCheckFailure: true
 					}
 					effect: {
 						type: AddThreats

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/unofficial/pc/setV02/V2-Rohan.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/unofficial/pc/setV02/V2-Rohan.hjson
@@ -107,6 +107,7 @@
 					type: RemoveCultureTokens
 					select: memory(chosenConditions)
 					count: 2
+					ignoreCostCheckFailure: true
 				}				
 			]
 			effect: [

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/unofficial/pc/setV02/V2-Sauron.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/unofficial/pc/setV02/V2-Sauron.hjson
@@ -640,6 +640,7 @@
 					cost: {
 						type: Exert
 						select: memory(pumpedTwilight)
+						ignoreCostCheckFailure: true
 					}
 					effect: {
 						type: AddBurdens

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/ValidateCards.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/ValidateCards.java
@@ -45,7 +45,7 @@ public class ValidateCards {
                     final LotroCardBlueprint lotroCardBlueprint = cardBlueprintBuilder.buildFromJson(blueprint, cardDefinition);
                 } catch (InvalidCardDefinitionException exp) {
                     System.out.println("Unable to load card " + blueprint);
-                    exp.printStackTrace();
+                    exp.printStackTrace(System.out);
                 }
             }
         } catch (Exception exp) {

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/PlayerSource.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/PlayerSource.java
@@ -1,5 +1,9 @@
 package com.gempukku.lotro.cards.build;
 
-public interface PlayerSource {
+public interface PlayerSource extends PreEvaluateAble {
     String getPlayer(ActionContext actionContext);
+
+    default boolean canPreEvaluate() {
+        return true;
+    }
 }

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/PreEvaluateAble.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/PreEvaluateAble.java
@@ -1,0 +1,5 @@
+package com.gempukku.lotro.cards.build;
+
+public interface PreEvaluateAble {
+    boolean canPreEvaluate();
+}

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/ValueSource.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/ValueSource.java
@@ -2,6 +2,7 @@ package com.gempukku.lotro.cards.build;
 
 import com.gempukku.lotro.logic.modifiers.evaluator.Evaluator;
 
-public interface ValueSource {
+public interface ValueSource extends PreEvaluateAble {
     Evaluator getEvaluator(ActionContext actionContext);
+    default boolean canPreEvaluate() { return true; }
 }

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/FieldUtils.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/FieldUtils.java
@@ -123,7 +123,7 @@ public class FieldUtils {
     public static void validateAllowedFields(JSONObject object, String... fields) throws InvalidCardDefinitionException {
         Set<String> keys = object.keySet();
         for (String key : keys) {
-            if (!key.equals("type") && !contains(fields, key))
+            if (!key.equals("type") && !key.equals("ignoreCostCheckFailure") && !contains(fields, key))
                 throw new InvalidCardDefinitionException("Unrecognized field: " + key);
         }
     }

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/AidCost.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/AidCost.java
@@ -14,7 +14,7 @@ public class AidCost implements EffectProcessor {
 
         final JSONObject[] costArray = FieldUtils.getObjectArray(value.get("cost"), "cost");
 
-        final EffectAppender[] costAppenders = environment.getEffectAppenderFactory().getEffectAppenders(costArray, environment);
+        final EffectAppender[] costAppenders = environment.getEffectAppenderFactory().getEffectAppenders(true, costArray, environment);
 
         if (costAppenders.length == 0)
             throw new InvalidCardDefinitionException("At least one cost is required on AidCost effects.");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/AssignmentCost.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/AssignmentCost.java
@@ -34,7 +34,7 @@ public class AssignmentCost implements EffectProcessor {
         if (text == null)
             throw new InvalidCardDefinitionException("Text is required for AssignmentCost effect");
 
-        final EffectAppender[] costAppenders = environment.getEffectAppenderFactory().getEffectAppenders(costArray, environment);
+        final EffectAppender[] costAppenders = environment.getEffectAppenderFactory().getEffectAppenders(true, costArray, environment);
         final Requirement[] requirements = environment.getRequirementFactory().getRequirements(conditionArray, environment);
 
         if (costAppenders.length == 0)

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/EffectAppender.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/EffectAppender.java
@@ -1,14 +1,19 @@
 package com.gempukku.lotro.cards.build.field.effect;
 
 import com.gempukku.lotro.cards.build.ActionContext;
+import com.gempukku.lotro.cards.build.PreEvaluateAble;
 import com.gempukku.lotro.logic.actions.CostToEffectAction;
 
-public interface EffectAppender {
+public interface EffectAppender extends PreEvaluateAble {
     void appendEffect(boolean cost, CostToEffectAction action, ActionContext actionContext);
 
     boolean isPlayableInFull(ActionContext actionContext);
 
     default boolean isPlayabilityCheckedForEffect() {
         return false;
+    }
+
+    default boolean canPreEvaluate() {
+        return true;
     }
 }

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/EffectAppenderProducer.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/EffectAppenderProducer.java
@@ -5,5 +5,5 @@ import com.gempukku.lotro.cards.build.InvalidCardDefinitionException;
 import org.json.simple.JSONObject;
 
 public interface EffectAppenderProducer {
-    EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException;
+    EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException;
 }

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/EffectUtils.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/EffectUtils.java
@@ -2,11 +2,22 @@ package com.gempukku.lotro.cards.build.field.effect;
 
 import com.gempukku.lotro.cards.build.CardGenerationEnvironment;
 import com.gempukku.lotro.cards.build.InvalidCardDefinitionException;
+import com.gempukku.lotro.cards.build.PreEvaluateAble;
 import com.gempukku.lotro.cards.build.Requirement;
 import com.gempukku.lotro.cards.build.field.FieldUtils;
 import org.json.simple.JSONObject;
 
 public class EffectUtils {
+    public static void validatePreEvaluate(boolean cost, JSONObject effectObject, PreEvaluateAble ... preEvaluateAbles) throws InvalidCardDefinitionException {
+        boolean ignoreCostCheckFailure = FieldUtils.getBoolean(effectObject.get("ignoreCostCheckFailure"), "ignoreCostCheckFailure", false);
+        if (cost && !ignoreCostCheckFailure) {
+            for (PreEvaluateAble preEvaluateAble : preEvaluateAbles) {
+                if (!preEvaluateAble.canPreEvaluate())
+                    throw new InvalidCardDefinitionException("Can't pre-evaluate a cost");
+            }
+        }
+    }
+
     public static void processRequirementsCostsAndEffects(JSONObject value, CardGenerationEnvironment environment, DefaultActionSource actionSource) throws InvalidCardDefinitionException {
         final JSONObject[] requirementArray = FieldUtils.getObjectArray(value.get("requires"), "requires");
         for (JSONObject requirement : requirementArray) {
@@ -26,17 +37,16 @@ public class EffectUtils {
 
         final EffectAppenderFactory effectAppenderFactory = environment.getEffectAppenderFactory();
         for (JSONObject cost : costArray) {
-            final EffectAppender effectAppender = effectAppenderFactory.getEffectAppender(cost, environment);
+            final EffectAppender effectAppender = effectAppenderFactory.getEffectAppender(true, cost, environment);
             actionSource.addPlayRequirement(
                     effectAppender::isPlayableInFull);
             actionSource.addCost(effectAppender);
         }
 
         for (JSONObject effect : effectArray) {
-            final EffectAppender effectAppender = effectAppenderFactory.getEffectAppender(effect, environment);
+            final EffectAppender effectAppender = effectAppenderFactory.getEffectAppender(false, effect, environment);
             if (effectAppender.isPlayabilityCheckedForEffect())
-                actionSource.addPlayRequirement(
-                        effectAppender::isPlayableInFull);
+                actionSource.addPlayRequirement(effectAppender::isPlayableInFull);
             actionSource.addEffect(effectAppender);
         }
     }

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/ExtraCost.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/ExtraCost.java
@@ -25,7 +25,7 @@ public class ExtraCost implements EffectProcessor {
         boolean skipValidate = FieldUtils.getBoolean(value.get("skipValidate"), "skipValidate", false);
 
         final JSONObject[] costArray = FieldUtils.getObjectArray(value.get("cost"), "cost");
-        final EffectAppender[] costAppenders = environment.getEffectAppenderFactory().getEffectAppenders(costArray, environment);
+        final EffectAppender[] costAppenders = environment.getEffectAppenderFactory().getEffectAppenders(true, costArray, environment);
 
         if (costAppenders.length == 0)
             throw new InvalidCardDefinitionException("At least one cost is required on ExtraCost effects.");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/PlayedInOtherPhase.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/PlayedInOtherPhase.java
@@ -20,7 +20,7 @@ public class PlayedInOtherPhase implements EffectProcessor {
         final JSONObject[] costArray = FieldUtils.getObjectArray(value.get("cost"), "cost");
 
         final Requirement[] conditions = environment.getRequirementFactory().getRequirements(conditionArray, environment);
-        EffectAppender[] costAppenders = environment.getEffectAppenderFactory().getEffectAppenders(costArray, environment);
+        EffectAppender[] costAppenders = environment.getEffectAppenderFactory().getEffectAppenders(true, costArray, environment);
 
         blueprint.appendPlayInOtherPhaseCondition(
                 new Requirement() {

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AddBurdens.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AddBurdens.java
@@ -19,7 +19,7 @@ import org.json.simple.JSONObject;
 
 public class AddBurdens implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "amount", "player");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("amount"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AddCultureTokens.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AddCultureTokens.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 public class AddCultureTokens implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "culture", "select", "memorize");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AddKeyword.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AddKeyword.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 
 public class AddKeyword implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "memorize", "keyword", "amount", "until");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AddModifier.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AddModifier.java
@@ -16,7 +16,7 @@ import org.json.simple.JSONObject;
 
 public class AddModifier implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "modifier", "until");
 
         final JSONObject modifierObj = (JSONObject) effectObject.get("modifier");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AddThreats.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AddThreats.java
@@ -20,7 +20,7 @@ import org.json.simple.JSONObject;
 
 public class AddThreats implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "amount", "player");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("amount"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AddTrigger.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AddTrigger.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 public class AddTrigger implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "trigger", "until", "optional", "requires", "cost", "effect");
 
         final TimeResolver.Time until = TimeResolver.resolveTime(effectObject.get("until"), "end(current)");
@@ -37,8 +37,8 @@ public class AddTrigger implements EffectAppenderProducer {
         final JSONObject[] effectArray = FieldUtils.getObjectArray(effectObject.get("effect"), "effect");
 
         final Requirement[] requirements = environment.getRequirementFactory().getRequirements(requirementArray, environment);
-        final EffectAppender[] costs = environment.getEffectAppenderFactory().getEffectAppenders(costArray, environment);
-        final EffectAppender[] effects = environment.getEffectAppenderFactory().getEffectAppenders(effectArray, environment);
+        final EffectAppender[] costs = environment.getEffectAppenderFactory().getEffectAppenders(true, costArray, environment);
+        final EffectAppender[] effects = environment.getEffectAppenderFactory().getEffectAppenders(false, effectArray, environment);
 
         return new DelayedAppender() {
             @Override

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AddTwilight.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AddTwilight.java
@@ -21,7 +21,7 @@ import org.json.simple.JSONObject;
 
 public class AddTwilight implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "amount", "memorize");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("amount"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AlterOverwhelmMultiplier.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AlterOverwhelmMultiplier.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 
 public class AlterOverwhelmMultiplier implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "until", "multiplier", "memorize");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AppendCardIdsToWhileInZone.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AppendCardIdsToWhileInZone.java
@@ -16,7 +16,7 @@ import org.json.simple.JSONObject;
 
 public class AppendCardIdsToWhileInZone implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "memory");
 
         String memory = FieldUtils.getString(effectObject.get("memory"), "memory");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AssignFpCharacterToSkirmish.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/AssignFpCharacterToSkirmish.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 
 public class AssignFpCharacterToSkirmish implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player", "fpCharacter", "minion", "memorizeMinion",
                 "memorizeFPCharacter", "ignoreExistingAssignments", "ignoreDefender", "ignoreAllyLocation", "preventCost", "preventText", "insteadEffect");
 
@@ -35,8 +35,8 @@ public class AssignFpCharacterToSkirmish implements EffectAppenderProducer {
             throw new InvalidCardDefinitionException("preventText and preventCost have to be specified (or not) together");
         if (insteadEffectArray.length > 0 && preventCostArray.length == 0)
             throw new InvalidCardDefinitionException("preventCost is required if insteadEffect is present");
-        EffectAppender[] preventEffectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(preventCostArray, environment);
-        EffectAppender[] insteadEffectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(insteadEffectArray, environment);
+        EffectAppender[] preventEffectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(false, preventCostArray, environment);
+        EffectAppender[] insteadEffectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(false, insteadEffectArray, environment);
 
         final String minionMemory = FieldUtils.getString(effectObject.get("memorizeMinion"), "memorizeMinion", "_tempMinion");
         final String fpCharacterMemory = FieldUtils.getString(effectObject.get("memorizeFPCharacter"), "memorizeFPCharacter", "_tempFpCharacter");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/CanPlayNextAction.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/CanPlayNextAction.java
@@ -13,7 +13,7 @@ import org.json.simple.JSONObject;
 
 public class CanPlayNextAction implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
 
         return new DelayedAppender() {

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/CancelAllAssignments.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/CancelAllAssignments.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 public class CancelAllAssignments implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
 
         return new DelayedAppender() {

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/CancelEvent.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/CancelEvent.java
@@ -14,7 +14,7 @@ import org.json.simple.JSONObject;
 
 public class CancelEvent implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
 
         return new DelayedAppender() {

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/CancelSkirmish.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/CancelSkirmish.java
@@ -17,7 +17,7 @@ import org.json.simple.JSONObject;
 
 public class CancelSkirmish implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "filter", "involving", "fierceOnly");
 
         final String filter = FieldUtils.getString(effectObject.get("filter"), "filter", "any");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/CancelSpecialAbility.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/CancelSpecialAbility.java
@@ -14,7 +14,7 @@ import org.json.simple.JSONObject;
 
 public class CancelSpecialAbility implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
 
         return new DelayedAppender() {

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Choice.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Choice.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 public class Choice implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player", "effects", "texts", "memorize");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");
@@ -30,7 +30,7 @@ public class Choice implements EffectAppenderProducer {
         if (effectArray.length != textArray.length)
             throw new InvalidCardDefinitionException("Number of texts and effects does not match in choice effect");
 
-        EffectAppender[] possibleEffectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(effectArray, environment);
+        EffectAppender[] possibleEffectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(cost, effectArray, environment);
 
         final PlayerSource playerSource = PlayerResolver.resolvePlayer(player);
 

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseACulture.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseACulture.java
@@ -18,7 +18,7 @@ import java.util.TreeSet;
 
 public class ChooseACulture implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "memorize");
 
         final String memorize = FieldUtils.getString(effectObject.get("memorize"), "memorize");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseAKeyword.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseAKeyword.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 public class ChooseAKeyword implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "memorize", "keywords", "text");
 
         final String memorize = FieldUtils.getString(effectObject.get("memorize"), "memorize");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseANumber.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseANumber.java
@@ -16,7 +16,7 @@ import org.json.simple.JSONObject;
 
 public class ChooseANumber implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player", "text", "from", "to", "default", "memorize");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseARace.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseARace.java
@@ -18,7 +18,7 @@ import java.util.TreeSet;
 
 public class ChooseARace implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "memorize");
 
         final String memorize = FieldUtils.getString(effectObject.get("memorize"), "memorize");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseActiveCards.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseActiveCards.java
@@ -12,7 +12,7 @@ import org.json.simple.JSONObject;
 
 public class ChooseActiveCards implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "player", "select", "memorize", "text");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseArbitraryCards.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseArbitraryCards.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 
 public class ChooseArbitraryCards implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "fromMemory", "count", "filter", "memorize", "text", "player");
 
         final String fromMemory = FieldUtils.getString(effectObject.get("fromMemory"), "fromMemory");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseCardsFromDiscard.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseCardsFromDiscard.java
@@ -12,7 +12,7 @@ import org.json.simple.JSONObject;
 
 public class ChooseCardsFromDiscard implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "memorize", "text");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseCardsFromDrawDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseCardsFromDrawDeck.java
@@ -12,7 +12,7 @@ import org.json.simple.JSONObject;
 
 public class ChooseCardsFromDrawDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player", "deck", "count", "select", "memorize", "text", "showAll");
 
         String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseCardsFromSingleStack.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseCardsFromSingleStack.java
@@ -6,20 +6,11 @@ import com.gempukku.lotro.cards.build.field.effect.EffectAppender;
 import com.gempukku.lotro.cards.build.field.effect.EffectAppenderProducer;
 import com.gempukku.lotro.cards.build.field.effect.appender.resolver.CardResolver;
 import com.gempukku.lotro.cards.build.field.effect.appender.resolver.ValueResolver;
-import com.gempukku.lotro.filters.Filters;
-import com.gempukku.lotro.game.PhysicalCard;
-import com.gempukku.lotro.logic.actions.CostToEffectAction;
-import com.gempukku.lotro.logic.effects.ExertCharactersEffect;
-import com.gempukku.lotro.logic.timing.Effect;
 import org.json.simple.JSONObject;
-
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
 
 public class ChooseCardsFromSingleStack implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "on", "memorize", "text");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseHowManyBurdensToSpot.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseHowManyBurdensToSpot.java
@@ -15,7 +15,7 @@ import org.json.simple.JSONObject;
 
 public class ChooseHowManyBurdensToSpot implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "memorize");
 
         final String memorize = FieldUtils.getString(effectObject.get("memorize"), "memorize");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseHowManyFPCulturesToSpot.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseHowManyFPCulturesToSpot.java
@@ -16,7 +16,7 @@ import org.json.simple.JSONObject;
 
 public class ChooseHowManyFPCulturesToSpot implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "memorize", "text");
 
         final String memorize = FieldUtils.getString(effectObject.get("memorize"), "memorize");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseHowManyThreatsToSpot.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseHowManyThreatsToSpot.java
@@ -15,7 +15,7 @@ import org.json.simple.JSONObject;
 
 public class ChooseHowManyThreatsToSpot implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "memorize");
 
         final String memorize = FieldUtils.getString(effectObject.get("memorize"), "memorize");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseHowManyToSpot.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseHowManyToSpot.java
@@ -19,7 +19,7 @@ import org.json.simple.JSONObject;
 
 public class ChooseHowManyToSpot implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "filter", "memorize", "text");
 
         final String filter = FieldUtils.getString(effectObject.get("filter"), "filter");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseHowManyTwilightTokensToSpot.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseHowManyTwilightTokensToSpot.java
@@ -15,7 +15,7 @@ import org.json.simple.JSONObject;
 
 public class ChooseHowManyTwilightTokensToSpot implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "memorize");
 
         final String memorize = FieldUtils.getString(effectObject.get("memorize"), "memorize");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseYesOrNo.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ChooseYesOrNo.java
@@ -17,7 +17,7 @@ import org.json.simple.JSONObject;
 
 public class ChooseYesOrNo implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "text", "player", "memorize", "yes", "no");
 
         final String text = FieldUtils.getString(effectObject.get("text"), "text");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ConsumeSurplusDamage.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ConsumeSurplusDamage.java
@@ -15,7 +15,7 @@ import org.json.simple.JSONObject;
 
 public class ConsumeSurplusDamage implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
         return new DelayedAppender() {
             @Override

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/CorruptRingBearer.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/CorruptRingBearer.java
@@ -13,7 +13,7 @@ import org.json.simple.JSONObject;
 
 public class CorruptRingBearer implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
         return new DelayedAppender() {
             @Override

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/CostToEffect.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/CostToEffect.java
@@ -7,7 +7,6 @@ import com.gempukku.lotro.cards.build.Requirement;
 import com.gempukku.lotro.cards.build.field.FieldUtils;
 import com.gempukku.lotro.cards.build.field.effect.EffectAppender;
 import com.gempukku.lotro.cards.build.field.effect.EffectAppenderProducer;
-import com.gempukku.lotro.cards.build.field.effect.EffectUtils;
 import com.gempukku.lotro.logic.actions.CostToEffectAction;
 import com.gempukku.lotro.logic.actions.SubAction;
 import com.gempukku.lotro.logic.effects.StackActionEffect;
@@ -16,15 +15,15 @@ import org.json.simple.JSONObject;
 
 public class CostToEffect implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "cost", "effect", "requires");
 
         final JSONObject[] costArray = FieldUtils.getObjectArray(effectObject.get("cost"), "cost");
         final JSONObject[] effectArray = FieldUtils.getObjectArray(effectObject.get("effect"), "effect");
         final JSONObject[] conditionArray = FieldUtils.getObjectArray(effectObject.get("requires"), "requires");
 
-        final EffectAppender[] costAppenders = environment.getEffectAppenderFactory().getEffectAppenders(costArray, environment);
-        final EffectAppender[] effectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(effectArray, environment);
+        final EffectAppender[] costAppenders = environment.getEffectAppenderFactory().getEffectAppenders(true, costArray, environment);
+        final EffectAppender[] effectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(false, effectArray, environment);
         final Requirement[] requirements = environment.getRequirementFactory().getRequirements(conditionArray, environment);
 
         return new DelayedAppender() {

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DisableArcheryTotalContribution.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DisableArcheryTotalContribution.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 
 public class DisableArcheryTotalContribution implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "memorize");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DisableSkirmishAssignment.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DisableSkirmishAssignment.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 
 public class DisableSkirmishAssignment implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "until");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DisableWounds.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DisableWounds.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 
 public class DisableWounds implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "until", "memorize", "requires");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DisableWoundsOver.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DisableWoundsOver.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 
 public class DisableWoundsOver implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "wounds", "memorize", "phase", "until");
 
         final int wounds = FieldUtils.getInteger(effectObject.get("wounds"), "wounds", 1);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DiscardBottomCardsFromDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DiscardBottomCardsFromDeck.java
@@ -17,7 +17,7 @@ import java.util.Collection;
 
 public class DiscardBottomCardsFromDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "deck", "count", "forced", "memorize");
 
         final String deck = FieldUtils.getString(effectObject.get("deck"), "deck", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DiscardCardAtRandomFromHand.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DiscardCardAtRandomFromHand.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 public class DiscardCardAtRandomFromHand implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "hand", "count", "forced");
 
         final String player = FieldUtils.getString(effectObject.get("hand"), "hand", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DiscardCardsFromDrawDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DiscardCardsFromDrawDeck.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 public class DiscardCardsFromDrawDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "memorize", "player", "deck", "showAll", "shuffle");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select", "choose(any)");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DiscardStackedCards.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DiscardStackedCards.java
@@ -13,7 +13,7 @@ import org.json.simple.JSONObject;
 
 public class DiscardStackedCards implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "on", "select", "count" ,"memorize");
 
         String on = FieldUtils.getString(effectObject.get("on"), "on", "any");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DiscardTopCardsFromDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DiscardTopCardsFromDeck.java
@@ -17,7 +17,7 @@ import java.util.Collection;
 
 public class DiscardTopCardsFromDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "deck", "count", "forced", "memorize");
 
         final String deck = FieldUtils.getString(effectObject.get("deck"), "deck", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DoWhile.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DoWhile.java
@@ -15,7 +15,7 @@ import org.json.simple.JSONObject;
 
 public class DoWhile implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "check", "effect");
 
         final JSONObject[] conditionArray = FieldUtils.getObjectArray(effectObject.get("check"), "check");
@@ -23,7 +23,7 @@ public class DoWhile implements EffectAppenderProducer {
         final Requirement[] conditions = environment.getRequirementFactory().getRequirements(conditionArray, environment);
         final JSONObject[] effectArray = FieldUtils.getObjectArray(effectObject.get("effect"), "effect");
 
-        final EffectAppender[] effectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(effectArray, environment);
+        final EffectAppender[] effectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(cost, effectArray, environment);
 
         return new DelayedAppender() {
             private boolean conditionsMatch(ActionContext actionContext) {

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DrawCards.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/DrawCards.java
@@ -14,7 +14,7 @@ import org.json.simple.JSONObject;
 
 public class DrawCards implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "player");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/EnableParticipationInArcheryFireAndSkirmishes.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/EnableParticipationInArcheryFireAndSkirmishes.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 
 public class EnableParticipationInArcheryFireAndSkirmishes implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "until", "count", "requires");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/EnableParticipationInSkirmishes.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/EnableParticipationInSkirmishes.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 
 public class EnableParticipationInSkirmishes implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "until", "count", "memorize");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/EndPhase.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/EndPhase.java
@@ -14,7 +14,7 @@ import org.json.simple.JSONObject;
 
 public class EndPhase implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
 
         return new DelayedAppender() {

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ExchangeCardsInHandWithCardsInDeadPile.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ExchangeCardsInHandWithCardsInDeadPile.java
@@ -25,7 +25,7 @@ import java.util.Set;
 
 public class ExchangeCardsInHandWithCardsInDeadPile implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "selectInHand", "selectInDeadPile", "countInHand", "countInDeadPile");
 
         final String selectInHand = FieldUtils.getString(effectObject.get("selectInHand"), "selectInHand");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ExchangeCardsInHandWithCardsInDiscard.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ExchangeCardsInHandWithCardsInDiscard.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 public class ExchangeCardsInHandWithCardsInDiscard implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "selectInHand", "selectInDiscard", "countInHand", "countInDiscard");
 
         final String selectInHand = FieldUtils.getString(effectObject.get("selectInHand"), "selectInHand");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ExchangeCardsInHandWithCardsStacked.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ExchangeCardsInHandWithCardsStacked.java
@@ -25,7 +25,7 @@ import java.util.Set;
 
 public class ExchangeCardsInHandWithCardsStacked implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "selectInHand", "selectInStacked", "countInHand", "countInStacked");
 
         final String selectInHand = FieldUtils.getString(effectObject.get("selectInHand"), "selectInHand");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ExchangeSite.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ExchangeSite.java
@@ -17,7 +17,7 @@ import org.json.simple.JSONObject;
 
 public class ExchangeSite implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "site1", "site2");
 
         final String site1 = FieldUtils.getString(effectObject.get("site1"), "site1");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Exhaust.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Exhaust.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 
 public class Exhaust implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player", "count", "select", "memorize");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ForEachPlayer.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ForEachPlayer.java
@@ -16,7 +16,7 @@ import org.json.simple.JSONObject;
 
 public class ForEachPlayer implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "effect");
 
         final JSONObject[] effectArray = FieldUtils.getObjectArray(effectObject.get("effect"), "effect");
@@ -24,7 +24,7 @@ public class ForEachPlayer implements EffectAppenderProducer {
         if (effectArray.length == 0)
             throw new InvalidCardDefinitionException("Effect is required for a ForEachPlayer effect.");
 
-        final EffectAppender[] effectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(effectArray, environment);
+        final EffectAppender[] effectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(cost, effectArray, environment);
 
         return new DelayedAppender() {
             @Override

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/GetCardsFromTopOfDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/GetCardsFromTopOfDeck.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 public class GetCardsFromTopOfDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "filter", "memorize");
 
         final String filter = FieldUtils.getString(effectObject.get("filter"), "filter");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Heal.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Heal.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 public class Heal implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "times", "memorize", "player");
 
         final ValueSource times = ValueResolver.resolveEvaluator(effectObject.get("times"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/IfEffect.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/IfEffect.java
@@ -15,7 +15,7 @@ import org.json.simple.JSONObject;
 
 public class IfEffect implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "check", "true", "false");
 
         final JSONObject[] conditionArray = FieldUtils.getObjectArray(effectObject.get("check"), "check");
@@ -23,8 +23,8 @@ public class IfEffect implements EffectAppenderProducer {
         final JSONObject[] falseEffects = FieldUtils.getObjectArray(effectObject.get("false"), "false");
 
         final Requirement[] conditions = environment.getRequirementFactory().getRequirements(conditionArray, environment);
-        final EffectAppender[] trueEffectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(trueEffects, environment);
-        final EffectAppender[] falseEffectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(falseEffects, environment);
+        final EffectAppender[] trueEffectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(cost, trueEffects, environment);
+        final EffectAppender[] falseEffectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(cost, falseEffects, environment);
 
         return new DelayedAppender() {
             @Override

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/IncrementPerPhaseLimit.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/IncrementPerPhaseLimit.java
@@ -18,7 +18,7 @@ import org.json.simple.JSONObject;
 
 public class IncrementPerPhaseLimit implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "limit", "phase", "perPlayer");
 
         Phase phase = FieldUtils.getEnum(Phase.class, effectObject.get("phase"), "phase");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/IncrementPerTurnLimit.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/IncrementPerTurnLimit.java
@@ -14,7 +14,7 @@ import org.json.simple.JSONObject;
 
 public class IncrementPerTurnLimit implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "limit");
 
         final int limit = FieldUtils.getInteger(effectObject.get("limit"), "limit", 1);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/IncrementToil.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/IncrementToil.java
@@ -15,7 +15,7 @@ import org.json.simple.JSONObject;
 
 public class IncrementToil implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
 
         return new DelayedAppender() {

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Kill.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Kill.java
@@ -20,7 +20,7 @@ import java.util.Collections;
 
 public class Kill implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "player", "memorize");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/LiberateSite.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/LiberateSite.java
@@ -17,7 +17,7 @@ import org.json.simple.JSONObject;
 
 public class LiberateSite implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "memorize", "controller");
 
         String memory = FieldUtils.getString(effectObject.get("memorize"), "memorize");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/LookAtHand.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/LookAtHand.java
@@ -16,7 +16,7 @@ import org.json.simple.JSONObject;
 
 public class LookAtHand implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "hand");
 
         final String player = FieldUtils.getString(effectObject.get("hand"), "hand", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/LookAtRandomCardsFromHand.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/LookAtRandomCardsFromHand.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 public class LookAtRandomCardsFromHand implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "hand", "count", "memorize");
 
         final String hand = FieldUtils.getString(effectObject.get("hand"), "hand");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/LookAtTopCardsOfDrawDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/LookAtTopCardsOfDrawDeck.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 public class LookAtTopCardsOfDrawDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "deck", "count", "memorize");
 
         final String deck = FieldUtils.getString(effectObject.get("deck"), "deck", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/MakeSelfRingBearer.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/MakeSelfRingBearer.java
@@ -13,7 +13,7 @@ import org.json.simple.JSONObject;
 
 public class MakeSelfRingBearer implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
 
         return new DelayedAppender() {

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/MemorizeActive.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/MemorizeActive.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 
 public class MemorizeActive implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "filter", "memory");
 
         final String filter = FieldUtils.getString(effectObject.get("filter"), "filter");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/MemorizeDiscard.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/MemorizeDiscard.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 public class MemorizeDiscard implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "filter", "memory", "uniqueTitles");
 
         final String filter = FieldUtils.getString(effectObject.get("filter"), "filter", "any");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/MemorizeInfo.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/MemorizeInfo.java
@@ -14,7 +14,7 @@ import org.json.simple.JSONObject;
 
 public class MemorizeInfo implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "info", "memory");
 
         final String info = FieldUtils.getString(effectObject.get("info"), "info");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/MemorizeNumber.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/MemorizeNumber.java
@@ -16,7 +16,7 @@ import org.json.simple.JSONObject;
 
 public class MemorizeNumber implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "amount", "memory");
 
         final String memory = FieldUtils.getString(effectObject.get("memory"), "memory");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/MemorizeStacked.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/MemorizeStacked.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 public class MemorizeStacked implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "filter", "on", "memory");
 
         final String filter = FieldUtils.getString(effectObject.get("filter"), "filter", "any");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/MemorizeTitle.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/MemorizeTitle.java
@@ -15,7 +15,7 @@ import org.json.simple.JSONObject;
 
 public class MemorizeTitle implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "from", "memory");
 
         final String from = FieldUtils.getString(effectObject.get("from"), "from");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/MemorizeTopOfDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/MemorizeTopOfDeck.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 public class MemorizeTopOfDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "memory", "count");
 
         final String memory = FieldUtils.getString(effectObject.get("memory"), "memory");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ModifyArcheryTotal.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ModifyArcheryTotal.java
@@ -19,7 +19,7 @@ import org.json.simple.JSONObject;
 
 public class ModifyArcheryTotal implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "amount", "side", "until");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("amount"), environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ModifyResistance.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ModifyResistance.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 public class ModifyResistance implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "amount", "count", "select", "until", "memorize", "limitPerCardThisPhase");
 
         final ValueSource amountSource = ValueResolver.resolveEvaluator(effectObject.get("amount"), environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ModifySiteNumber.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ModifySiteNumber.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 
 public class ModifySiteNumber implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "amount", "count", "select", "until", "memorize");
 
         final ValueSource amountSource = ValueResolver.resolveEvaluator(effectObject.get("amount"), environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ModifyStrength.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ModifyStrength.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 public class ModifyStrength implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "amount", "count", "select", "until", "memorize", "limitPerCardThisPhase");
 
         final ValueSource amountSource = ValueResolver.resolveEvaluator(effectObject.get("amount"), environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Multiple.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Multiple.java
@@ -9,12 +9,12 @@ import org.json.simple.JSONObject;
 
 public class Multiple implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "effects");
 
         final JSONObject[] effectArray = FieldUtils.getObjectArray(effectObject.get("effects"), "effects");
 
-        final EffectAppender[] effectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(effectArray, environment);
+        final EffectAppender[] effectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(cost, effectArray, environment);
 
         MultiEffectAppender multiEffectAppender = new MultiEffectAppender();
         multiEffectAppender.setPlayabilityCheckedForEffect(true);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/NegateWound.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/NegateWound.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 
 public class NegateWound implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select", "all(any)");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Optional.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Optional.java
@@ -16,7 +16,7 @@ import org.json.simple.JSONObject;
 
 public class Optional implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player", "text", "effect");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");
@@ -27,7 +27,7 @@ public class Optional implements EffectAppenderProducer {
             throw new InvalidCardDefinitionException("There is a text required for optional effects");
 
         final PlayerSource playerSource = PlayerResolver.resolvePlayer(player);
-        final EffectAppender[] effectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(effectArray, environment);
+        final EffectAppender[] effectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(cost, effectArray, environment);
 
         return new DelayedAppender() {
             @Override

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PlaceNoWoundForExert.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PlaceNoWoundForExert.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 
 public class PlaceNoWoundForExert implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select", "all(any)");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PlayCardFromDeadPile.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PlayCardFromDeadPile.java
@@ -6,7 +6,6 @@ import com.gempukku.lotro.cards.build.field.effect.EffectAppender;
 import com.gempukku.lotro.cards.build.field.effect.EffectAppenderProducer;
 import com.gempukku.lotro.cards.build.field.effect.appender.resolver.CardResolver;
 import com.gempukku.lotro.cards.build.field.effect.appender.resolver.ValueResolver;
-import com.gempukku.lotro.common.Filterable;
 import com.gempukku.lotro.filters.Filters;
 import com.gempukku.lotro.game.PhysicalCard;
 import com.gempukku.lotro.game.state.LotroGame;
@@ -15,7 +14,6 @@ import com.gempukku.lotro.logic.actions.CostToEffectAction;
 import com.gempukku.lotro.logic.effects.StackActionEffect;
 import com.gempukku.lotro.logic.modifiers.evaluator.ConstantEvaluator;
 import com.gempukku.lotro.logic.timing.Effect;
-import com.gempukku.lotro.logic.timing.ExtraFilters;
 import com.gempukku.lotro.logic.timing.FailedEffect;
 import org.json.simple.JSONObject;
 
@@ -23,7 +21,7 @@ import java.util.Collection;
 
 public class PlayCardFromDeadPile implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "discount", "memorize");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PlayCardFromDiscard.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PlayCardFromDiscard.java
@@ -26,7 +26,7 @@ import java.util.Collection;
 
 public class PlayCardFromDiscard implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject,  "player", "select", "on", "discount", "maxDiscount", "removedTwilight", "optional", "extraEffects", "memorize");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");
@@ -41,7 +41,7 @@ public class PlayCardFromDiscard implements EffectAppenderProducer {
         final String memorize = FieldUtils.getString(effectObject.get("memorize"), "memorize", "_temp");
 
         final JSONObject[] extraEffectsArray = FieldUtils.getObjectArray(effectObject.get("extraEffects"), "extraEffects");
-        final EffectAppender[] extraEffectsAppenders = environment.getEffectAppenderFactory().getEffectAppenders(extraEffectsArray, environment);
+        final EffectAppender[] extraEffectsAppenders = environment.getEffectAppenderFactory().getEffectAppenders(cost, extraEffectsArray, environment);
 
         final FilterableSource onFilterableSource = (onFilter != null) ? environment.getFilterFactory().generateFilter(onFilter, environment) : null;
 

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PlayCardFromDrawDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PlayCardFromDrawDeck.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 
 public class PlayCardFromDrawDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "on", "discount", "memorize", "shuffle", "showAll");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PlayCardFromHand.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PlayCardFromHand.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 
 public class PlayCardFromHand implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "on", "discount", "maxDiscount", "removedTwilight", "ignoreInDeadPile", "ignoreRoamingPenalty", "memorize");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PlayCardFromStacked.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PlayCardFromStacked.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 
 public class PlayCardFromStacked implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "on", "discount", "removedTwilight", "assumePlayable", "memorize");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select", "choose(any)");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PlayNextSite.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PlayNextSite.java
@@ -19,7 +19,7 @@ import org.json.simple.JSONObject;
 
 public class PlayNextSite implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "filter", "memorize");
         final String filter = FieldUtils.getString(effectObject.get("filter"), "filter", "any");
         final String memorize = FieldUtils.getString(effectObject.get("memorize"), "memorize");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PlaySite.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PlaySite.java
@@ -19,7 +19,7 @@ import org.json.simple.JSONObject;
 
 public class PlaySite implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "block", "filter", "number", "memorize", "player");
 
         final String blockString = FieldUtils.getString(effectObject.get("block"), "block");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PreventAddingAllBurdens.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PreventAddingAllBurdens.java
@@ -15,7 +15,7 @@ import org.json.simple.JSONObject;
 
 public class PreventAddingAllBurdens implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
 
         MultiEffectAppender result = new MultiEffectAppender();

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PreventAllWounds.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PreventAllWounds.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 
 public class PreventAllWounds implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select", "choose(any)");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PreventCardEffectAppender.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PreventCardEffectAppender.java
@@ -16,7 +16,7 @@ import org.json.simple.JSONObject;
 
 public class PreventCardEffectAppender implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "memorize");
 
         String select = FieldUtils.getString(effectObject.get("select"), "select");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PreventEffect.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PreventEffect.java
@@ -13,7 +13,7 @@ import org.json.simple.JSONObject;
 
 public class PreventEffect implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
 
         MultiEffectAppender result = new MultiEffectAppender();

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PreventSpecialAbility.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PreventSpecialAbility.java
@@ -18,7 +18,7 @@ import org.json.simple.JSONObject;
 
 public class PreventSpecialAbility implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
 
         MultiEffectAppender result = new MultiEffectAppender();

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PreventWound.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PreventWound.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 
 public class PreventWound implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "memorize");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select", "all(any)");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PreventableAppenderProducer.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PreventableAppenderProducer.java
@@ -12,7 +12,7 @@ import org.json.simple.JSONObject;
 
 public class PreventableAppenderProducer implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "text", "player", "effect", "cost", "instead");
 
         final String text = FieldUtils.getString(effectObject.get("text"), "text");
@@ -27,9 +27,9 @@ public class PreventableAppenderProducer implements EffectAppenderProducer {
             throw new InvalidCardDefinitionException("Player is required for preventable effect");
 
         final PlayerSource preventingPlayerSource = PlayerResolver.resolvePlayer(player);
-        final EffectAppender[] effectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(effectArray, environment);
-        final EffectAppender[] costAppenders = environment.getEffectAppenderFactory().getEffectAppenders(costArray, environment);
-        final EffectAppender[] insteadAppenders = environment.getEffectAppenderFactory().getEffectAppenders(insteadArray, environment);
+        final EffectAppender[] effectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(cost, effectArray, environment);
+        final EffectAppender[] costAppenders = environment.getEffectAppenderFactory().getEffectAppenders(true, costArray, environment);
+        final EffectAppender[] insteadAppenders = environment.getEffectAppenderFactory().getEffectAppenders(true, insteadArray, environment);
 
         return new PreventableEffectAppender(preventingPlayerSource, text, Predicates.alwaysTrue(), costAppenders, effectAppenders, insteadAppenders);
     }

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromDeckIntoHand.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromDeckIntoHand.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 public class PutCardsFromDeckIntoHand implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "shuffle", "reveal", "showAll");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromDeckOnBottomOfDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromDeckOnBottomOfDeck.java
@@ -22,7 +22,7 @@ import java.util.*;
 
 public class PutCardsFromDeckOnBottomOfDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "reveal");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromDeckOnTopOfDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromDeckOnTopOfDeck.java
@@ -22,7 +22,7 @@ import java.util.*;
 
 public class PutCardsFromDeckOnTopOfDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "reveal");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromDiscardIntoHand.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromDiscardIntoHand.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 public class PutCardsFromDiscardIntoHand implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "player", "discard", "memorize");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromDiscardOnBottomOfDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromDiscardOnBottomOfDeck.java
@@ -22,7 +22,7 @@ import java.util.*;
 
 public class PutCardsFromDiscardOnBottomOfDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromDiscardOnTopOfDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromDiscardOnTopOfDeck.java
@@ -22,7 +22,7 @@ import java.util.*;
 
 public class PutCardsFromDiscardOnTopOfDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromHandOnBottomOfDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromHandOnBottomOfDeck.java
@@ -22,7 +22,7 @@ import java.util.*;
 
 public class PutCardsFromHandOnBottomOfDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player", "select", "count", "reveal");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromHandOnTopOfDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromHandOnTopOfDeck.java
@@ -22,7 +22,7 @@ import java.util.*;
 
 public class PutCardsFromHandOnTopOfDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player", "hand", "select", "count", "reveal");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromPlayOnBottomOfDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromPlayOnBottomOfDeck.java
@@ -22,7 +22,7 @@ import java.util.*;
 
 public class PutCardsFromPlayOnBottomOfDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player", "select", "count");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromPlayOnTopOfDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutCardsFromPlayOnTopOfDeck.java
@@ -22,7 +22,7 @@ import java.util.*;
 
 public class PutCardsFromPlayOnTopOfDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player", "select", "count");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutOnRing.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutOnRing.java
@@ -13,7 +13,7 @@ import org.json.simple.JSONObject;
 
 public class PutOnRing implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
         return new DelayedAppender() {
             @Override

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutPlayedEventIntoHand.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutPlayedEventIntoHand.java
@@ -15,7 +15,7 @@ import org.json.simple.JSONObject;
 
 public class PutPlayedEventIntoHand implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "filter");
 
         final String filter = FieldUtils.getString(effectObject.get("filter"), "filter", "self");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutPlayedEventOnBottomOfDrawDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutPlayedEventOnBottomOfDrawDeck.java
@@ -13,7 +13,7 @@ import org.json.simple.JSONObject;
 
 public class PutPlayedEventOnBottomOfDrawDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
 
         return new DelayedAppender() {

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutPlayedEventOnTopOfDrawDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutPlayedEventOnTopOfDrawDeck.java
@@ -13,7 +13,7 @@ import org.json.simple.JSONObject;
 
 public class PutPlayedEventOnTopOfDrawDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
 
         return new DelayedAppender() {

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutRandomCardFromHandBeneathDrawDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutRandomCardFromHandBeneathDrawDeck.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 public class PutRandomCardFromHandBeneathDrawDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "hand", "count");
 
         final String player = FieldUtils.getString(effectObject.get("hand"), "hand", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutStackedCardsIntoHand.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/PutStackedCardsIntoHand.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 public class PutStackedCardsIntoHand implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "on");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ReconcileHand.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ReconcileHand.java
@@ -15,7 +15,7 @@ import org.json.simple.JSONObject;
 
 public class ReconcileHand implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RefreshSelf.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RefreshSelf.java
@@ -8,15 +8,13 @@ import com.gempukku.lotro.cards.build.field.effect.EffectAppender;
 import com.gempukku.lotro.cards.build.field.effect.EffectAppenderProducer;
 import com.gempukku.lotro.game.state.LotroGame;
 import com.gempukku.lotro.logic.actions.CostToEffectAction;
-import com.gempukku.lotro.logic.effects.PutOnTheOneRingEffect;
 import com.gempukku.lotro.logic.timing.Effect;
-import com.gempukku.lotro.logic.timing.PlayConditions;
 import com.gempukku.lotro.logic.timing.UnrespondableEffect;
 import org.json.simple.JSONObject;
 
 public class RefreshSelf implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
 
         //This is intended to be used with cards using CopyCard, such as Hobbit Farmer.

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ReinforceTokens.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ReinforceTokens.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 public class ReinforceTokens implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "culture", "select", "memorize", "times", "player");
 
         final Culture culture = FieldUtils.getEnum(Culture.class, effectObject.get("culture"), "culture");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveAllTokens.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveAllTokens.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 public class RemoveAllTokens implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select", "self");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveBurdens.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveBurdens.java
@@ -19,7 +19,7 @@ import org.json.simple.JSONObject;
 
 public class RemoveBurdens implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player", "amount");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveCardsInDeadPileFromGame.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveCardsInDeadPileFromGame.java
@@ -18,7 +18,7 @@ import java.util.Collection;
 
 public class RemoveCardsInDeadPileFromGame implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "player");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveCardsInDeckFromGame.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveCardsInDeckFromGame.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 
 public class RemoveCardsInDeckFromGame implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "player", "deck", "shuffle", "showAll");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveCardsInDiscardFromGame.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveCardsInDiscardFromGame.java
@@ -17,7 +17,7 @@ import java.util.Collection;
 
 public class RemoveCardsInDiscardFromGame implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "player");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveCharacterFromSkirmish.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveCharacterFromSkirmish.java
@@ -18,7 +18,7 @@ import org.json.simple.JSONObject;
 
 public class RemoveCharacterFromSkirmish implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player", "select", "memorize");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveFromTheGame.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveFromTheGame.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 public class RemoveFromTheGame implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player", "count", "select", "memorize", "memorizeStackedCards");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveKeyword.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveKeyword.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 
 public class RemoveKeyword implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "memorize", "keyword", "until", "keywordFromMemory");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemovePlayedEventFromTheGame.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemovePlayedEventFromTheGame.java
@@ -4,25 +4,16 @@ import com.gempukku.lotro.cards.build.*;
 import com.gempukku.lotro.cards.build.field.FieldUtils;
 import com.gempukku.lotro.cards.build.field.effect.EffectAppender;
 import com.gempukku.lotro.cards.build.field.effect.EffectAppenderProducer;
-import com.gempukku.lotro.cards.build.field.effect.appender.resolver.CardResolver;
-import com.gempukku.lotro.cards.build.field.effect.appender.resolver.PlayerResolver;
-import com.gempukku.lotro.cards.build.field.effect.appender.resolver.ValueResolver;
 import com.gempukku.lotro.game.PhysicalCard;
 import com.gempukku.lotro.logic.actions.CostToEffectAction;
-import com.gempukku.lotro.logic.effects.PutPlayedEventIntoHandEffect;
-import com.gempukku.lotro.logic.effects.RemoveCardsFromTheGameEffect;
 import com.gempukku.lotro.logic.effects.RemovePlayedEventFromTheGameEffect;
 import com.gempukku.lotro.logic.timing.Effect;
 import com.gempukku.lotro.logic.timing.results.PlayCardResult;
 import org.json.simple.JSONObject;
 
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-
 public class RemovePlayedEventFromTheGame implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "filter");
 
         final String filter = FieldUtils.getString(effectObject.get("filter"), "filter", "self");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveText.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveText.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 
 public class RemoveText implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "until", "memorize");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveThreats.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveThreats.java
@@ -21,7 +21,7 @@ import org.json.simple.JSONObject;
 
 public class RemoveThreats implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "amount");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("amount"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveTokensCumulative.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveTokensCumulative.java
@@ -21,7 +21,7 @@ import org.json.simple.JSONObject;
 
 public class RemoveTokensCumulative implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "culture", "filter");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 0, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveTwilight.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RemoveTwilight.java
@@ -21,7 +21,7 @@ import org.json.simple.JSONObject;
 
 public class RemoveTwilight implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "amount", "memorize");
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("amount"), 1, environment);
 

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ReorderTopCardsOfDrawDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ReorderTopCardsOfDrawDeck.java
@@ -14,7 +14,7 @@ import org.json.simple.JSONObject;
 
 public class ReorderTopCardsOfDrawDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "player", "deck");
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Repeat.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Repeat.java
@@ -18,13 +18,13 @@ import java.util.Arrays;
 
 public class Repeat implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "times", "effect");
 
         final ValueSource timesSource = ValueResolver.resolveEvaluator(effectObject.get("times"), environment);
         final JSONObject[] effectArray = FieldUtils.getObjectArray(effectObject.get("effect"), "effect");
 
-        final EffectAppender[] effectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(effectArray, environment);
+        final EffectAppender[] effectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(cost, effectArray, environment);
 
         return new DelayedAppender() {
             @Override

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ReplaceInSkirmish.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ReplaceInSkirmish.java
@@ -17,7 +17,7 @@ import org.json.simple.JSONObject;
 
 public class ReplaceInSkirmish implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "filter", "with");
 
         final String filter = FieldUtils.getString(effectObject.get("filter"), "filter");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ResetWhileInZoneData.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ResetWhileInZoneData.java
@@ -14,7 +14,7 @@ import org.json.simple.JSONObject;
 
 public class ResetWhileInZoneData implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
 
         return new DelayedAppender() {

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ReturnToHand.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ReturnToHand.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 
 public class ReturnToHand implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "count", "player");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RevealBottomCardsOfDrawDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RevealBottomCardsOfDrawDeck.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 public class RevealBottomCardsOfDrawDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "deck", "count", "memorize");
 
         final String deck = FieldUtils.getString(effectObject.get("deck"), "deck", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RevealCards.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RevealCards.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 
 public class RevealCards implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "memorize");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select", "choose(any)");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RevealCardsFromAdventureDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RevealCardsFromAdventureDeck.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 
 public class RevealCardsFromAdventureDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "memorize", "player");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RevealCardsFromHand.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RevealCardsFromHand.java
@@ -16,7 +16,7 @@ import java.util.Collection;
 
 public class RevealCardsFromHand implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "select", "memorize", "hand");
 
         final String hand = FieldUtils.getString(effectObject.get("hand"), "hand", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RevealHand.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RevealHand.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 
 public class RevealHand implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "hand", "memorize");
 
         final String player = FieldUtils.getString(effectObject.get("hand"), "hand", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RevealRandomCardsFromHand.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RevealRandomCardsFromHand.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 public class RevealRandomCardsFromHand implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "hand", "forced", "count", "memorize");
 
         final String hand = FieldUtils.getString(effectObject.get("hand"), "hand", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RevealTopCardsOfDrawDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/RevealTopCardsOfDrawDeck.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 public class RevealTopCardsOfDrawDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "deck", "count", "memorize");
 
         final String deck = FieldUtils.getString(effectObject.get("deck"), "deck", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/SendMessage.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/SendMessage.java
@@ -15,7 +15,7 @@ import org.json.simple.JSONObject;
 
 public class SendMessage implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "text");
 
         final String text = FieldUtils.getString(effectObject.get("text"), "text");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/SetFPStrengthOverride.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/SetFPStrengthOverride.java
@@ -18,7 +18,7 @@ import org.json.simple.JSONObject;
 
 public class SetFPStrengthOverride implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "amount");
 
         ValueSource amountSource = ValueResolver.resolveEvaluator(effectObject.get("amount"), environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/SetShadowStrengthOverride.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/SetShadowStrengthOverride.java
@@ -18,7 +18,7 @@ import org.json.simple.JSONObject;
 
 public class SetShadowStrengthOverride implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "amount");
 
         ValueSource amountSource = ValueResolver.resolveEvaluator(effectObject.get("amount"), environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/SetupExtraAssignmentAndSkirmishes.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/SetupExtraAssignmentAndSkirmishes.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 public class SetupExtraAssignmentAndSkirmishes implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "filter");
 
         final String filter = FieldUtils.getString(effectObject.get("filter"), "filter");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ShadowCantHaveInitiative.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ShadowCantHaveInitiative.java
@@ -15,7 +15,7 @@ import org.json.simple.JSONObject;
 
 public class ShadowCantHaveInitiative implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "until");
 
         final TimeResolver.Time until = TimeResolver.resolveTime(effectObject.get("until"), "end(current)");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ShuffleCardsFromDiscardIntoDrawDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ShuffleCardsFromDiscardIntoDrawDeck.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 
 public class ShuffleCardsFromDiscardIntoDrawDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "count");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select", "choose(any)");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ShuffleCardsFromHandIntoDrawDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ShuffleCardsFromHandIntoDrawDeck.java
@@ -17,7 +17,7 @@ import java.util.Collection;
 
 public class ShuffleCardsFromHandIntoDrawDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player", "select", "count", "memorize");
 
         String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ShuffleCardsFromPlayIntoDrawDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ShuffleCardsFromPlayIntoDrawDeck.java
@@ -21,7 +21,7 @@ import java.util.Set;
 
 public class ShuffleCardsFromPlayIntoDrawDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player", "select", "count", "includeStacked", "memorize", "memorizeStacked");
 
         String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ShuffleDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ShuffleDeck.java
@@ -15,7 +15,7 @@ import org.json.simple.JSONObject;
 
 public class ShuffleDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "deck");
 
         String player = FieldUtils.getString(effectObject.get("deck"), "deck", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ShuffleHandIntoDrawDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/ShuffleHandIntoDrawDeck.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 public class ShuffleHandIntoDrawDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player");
 
         String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Spot.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Spot.java
@@ -17,7 +17,7 @@ import org.json.simple.JSONObject;
 
 public class Spot implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "filter", "select", "memorize", "text");
 
         final ValueSource valueSource = ValueResolver.resolveEvaluator(effectObject.get("count"), 1, environment);

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StackCardsFromDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StackCardsFromDeck.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 public class StackCardsFromDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "where", "count", "shuffle", "showAll");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select", "choose(any)");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StackCardsFromDiscard.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StackCardsFromDiscard.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 public class StackCardsFromDiscard implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "where", "count");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select", "choose(any)");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StackCardsFromHand.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StackCardsFromHand.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 public class StackCardsFromHand implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "where", "count", "memorize");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select", "choose(any)");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StackCardsFromPlay.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StackCardsFromPlay.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 public class StackCardsFromPlay implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "where", "count");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select", "choose(any)");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StackPlayedEvent.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StackPlayedEvent.java
@@ -17,7 +17,7 @@ import org.json.simple.JSONObject;
 
 public class StackPlayedEvent implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "where");
 
         final String where = FieldUtils.getString(effectObject.get("where"), "where");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StackTopCardsOfDrawDeck.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StackTopCardsOfDrawDeck.java
@@ -18,7 +18,7 @@ import org.json.simple.JSONObject;
 
 public class StackTopCardsOfDrawDeck implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "deck", "where", "count");
 
         final String deck = FieldUtils.getString(effectObject.get("deck"), "deck", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StartSkirmish.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StartSkirmish.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 public class StartSkirmish implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "fpCharacter", "against");
 
         final String fpCharacter = FieldUtils.getString(effectObject.get("fpCharacter"), "fpCharacter");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StoreCulture.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StoreCulture.java
@@ -16,7 +16,7 @@ import org.json.simple.JSONObject;
 
 public class StoreCulture implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "memory");
 
         final String memory = FieldUtils.getString(effectObject.get("memory"), "memory");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StoreKeyword.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StoreKeyword.java
@@ -16,7 +16,7 @@ import org.json.simple.JSONObject;
 
 public class StoreKeyword implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "memory");
 
         final String memory = FieldUtils.getString(effectObject.get("memory"), "memory");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StoreRaceFromCard.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StoreRaceFromCard.java
@@ -16,7 +16,7 @@ import org.json.simple.JSONObject;
 
 public class StoreRaceFromCard implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "memory");
 
         final String memory = FieldUtils.getString(effectObject.get("memory"), "memory");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StoreWhileInZone.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/StoreWhileInZone.java
@@ -15,7 +15,7 @@ import org.json.simple.JSONObject;
 
 public class StoreWhileInZone implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "memory");
 
         final String memory = FieldUtils.getString(effectObject.get("memory"), "memory");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/TakeControlOfSite.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/TakeControlOfSite.java
@@ -17,7 +17,7 @@ import org.json.simple.JSONObject;
 
 public class TakeControlOfSite implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "player");
 
         String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/TakeOffRing.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/TakeOffRing.java
@@ -13,7 +13,7 @@ import org.json.simple.JSONObject;
 
 public class TakeOffRing implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject);
         return new DelayedAppender() {
             @Override

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Transfer.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Transfer.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 
 public class Transfer implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "where", "checkTarget", "fromSupport", "memorizeTransferred", "memorizeTarget");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/TransferFromDiscard.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/TransferFromDiscard.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public class TransferFromDiscard implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "where");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/TransferToSupport.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/TransferToSupport.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 public class TransferToSupport implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "memorizeBearer");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/TurnIntoMinion.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/TurnIntoMinion.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 public class TurnIntoMinion implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "select", "count", "strength", "vitality", "keywords", "race", "until", "memorize");
 
         final String select = FieldUtils.getString(effectObject.get("select"), "select", "choose(any)");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Wound.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/Wound.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 public class Wound implements EffectAppenderProducer {
     @Override
-    public EffectAppender createEffectAppender(JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
+    public EffectAppender createEffectAppender(boolean cost, JSONObject effectObject, CardGenerationEnvironment environment) throws InvalidCardDefinitionException {
         FieldUtils.validateAllowedFields(effectObject, "count", "times", "select", "memorize", "player");
 
         final String player = FieldUtils.getString(effectObject.get("player"), "player", "you");

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/resolver/CardResolver.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/resolver/CardResolver.java
@@ -538,6 +538,11 @@ public class CardResolver {
                     additionalFilterable = filter.getFilterable(actionContext);
                 return Filters.filter(actionContext.getGame(), cardSource.apply(actionContext), Filters.in(cardsFromMemory), additionalFilterable);
             }
+
+            @Override
+            public boolean canPreEvaluate() {
+                return false;
+            }
         };
     }
 

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/resolver/PlayerResolver.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/appender/resolver/PlayerResolver.java
@@ -34,7 +34,17 @@ public class PlayerResolver {
         }
         else if (type.toLowerCase().startsWith("frommemory(") && type.endsWith(")")) {
             String memory = type.substring(type.indexOf("(") + 1, type.lastIndexOf(")"));
-            return (actionContext) -> actionContext.getValueFromMemory(memory);
+            return new PlayerSource() {
+                @Override
+                public String getPlayer(ActionContext actionContext) {
+                    return actionContext.getValueFromMemory(memory);
+                }
+
+                @Override
+                public boolean canPreEvaluate() {
+                    return false;
+                }
+            };
         }
         throw new InvalidCardDefinitionException("Unable to resolve player resolver of type: " + type);
     }

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/filter/FilterFactory.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/filter/FilterFactory.java
@@ -151,11 +151,6 @@ public class FilterFactory {
                     final CharacterLostSkirmishResult lostSkirmish = (CharacterLostSkirmishResult) actionContext.getEffectResult();
                     return lostSkirmish.getLoser();
                 });
-        simpleFilters.put("skirmishwinner",
-                (actionContext) -> {
-                    final CharacterWonSkirmishResult lostSkirmish = (CharacterWonSkirmishResult) actionContext.getEffectResult();
-                    return lostSkirmish.getWinner();
-                });
         simpleFilters.put("storedculture",
                 (actionContext) -> (Filter) (game, physicalCard) -> {
                     PhysicalCard.WhileInZoneData data = actionContext.getSource().getWhileInZoneData();

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/filter/FilterFactory.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/filter/FilterFactory.java
@@ -14,6 +14,7 @@ import com.gempukku.lotro.logic.modifiers.evaluator.Evaluator;
 import com.gempukku.lotro.logic.modifiers.evaluator.SingleMemoryEvaluator;
 import com.gempukku.lotro.logic.timing.Effect;
 import com.gempukku.lotro.logic.timing.results.CharacterLostSkirmishResult;
+import com.gempukku.lotro.logic.timing.results.CharacterWonSkirmishResult;
 
 import java.util.*;
 
@@ -149,6 +150,11 @@ public class FilterFactory {
                 (actionContext) -> {
                     final CharacterLostSkirmishResult lostSkirmish = (CharacterLostSkirmishResult) actionContext.getEffectResult();
                     return lostSkirmish.getLoser();
+                });
+        simpleFilters.put("skirmishwinner",
+                (actionContext) -> {
+                    final CharacterWonSkirmishResult lostSkirmish = (CharacterWonSkirmishResult) actionContext.getEffectResult();
+                    return lostSkirmish.getWinner();
                 });
         simpleFilters.put("storedculture",
                 (actionContext) -> (Filter) (game, physicalCard) -> {

--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/modifier/ExtraCostToPlay.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/modifier/ExtraCostToPlay.java
@@ -23,7 +23,7 @@ public class ExtraCostToPlay implements ModifierSourceProducer {
         final Requirement[] requirements = environment.getRequirementFactory().getRequirements(conditionArray, environment);
 
         final JSONObject[] effectArray = FieldUtils.getObjectArray(object.get("cost"), "cost");
-        final EffectAppender[] effectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(effectArray, environment);
+        final EffectAppender[] effectAppenders = environment.getEffectAppenderFactory().getEffectAppenders(true, effectArray, environment);
 
         final boolean requiresRanger = FieldUtils.getBoolean(object.get("requiresRanger"), "requiresRanger", false);
 


### PR DESCRIPTION
This branch adds an extra "ignoreCostCheckFailure" parameter to any effect. If it's present and set to "true", the effect produced will "return true", if checking for playability throws an exception.
In addition - there is an easy method to validate, if any of the values being resolved in EffectAppenderProducer could result in such error, if they cannot be pre-evaluated (mostly due to using "memory").
These checks so far have been added to "Exert", "DiscardFromHand", "DiscardFromPlay" and "RemoveCultureTokens". If you can think of any other effects commonly used as costs, that could result in such error checks, feel free to add the following code to the EffectAppenderProducer for this effect:
`EffectUtils.validatePreEvaluate(cost, effectObject, playerSource, countSource, cardResolver);`