### PR TITLE
Bondolin/handle title filter spaces

### DIFF
--- a/gemp-lotr/docker/gemp_app.Dockerfile
+++ b/gemp-lotr/docker/gemp_app.Dockerfile
@@ -39,7 +39,7 @@ ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 # Enables the JRE remote debugging; perhaps comment this out in a production build
-ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n
+#ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n
 
 
 #####################################################################

--- a/gemp-lotr/docker/gemp_app.Dockerfile
+++ b/gemp-lotr/docker/gemp_app.Dockerfile
@@ -39,7 +39,7 @@ ARG USER_HOME_DIR="/root"
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 # Enables the JRE remote debugging; perhaps comment this out in a production build
-#ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n
+ENV JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,address=*:8000,server=y,suspend=n
 
 
 #####################################################################

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/cards/CardFilter.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/cards/CardFilter.js
@@ -889,7 +889,7 @@ var CardFilter = Class.extend({
 		
 		var name = $("#nameInput").prop("value");
 		if (name.trim() != "" && !predefFilter.includes("name:")) {
-			var nameElems = name.split(" ");
+			var nameElems = name.split(" ").filter(Boolean);
 			name = "";
 			for (var i = 0; i < nameElems.length; i++)
 				name += " name:" + nameElems[i];


### PR DESCRIPTION
The "Name contains" card filter was choking when extra spaces were included.  This fixes by filtering the string split as per https://stackoverflow.com/a/64942185/1399272.