### PR TITLE
Fix: Brooding on tomorrow working in Fellowship Phase

### DIFF
--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set10/set10-Gandalf.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set10/set10-Gandalf.hjson
@@ -73,10 +73,19 @@
 					type: losesInitiative
 					side: free people
 				}
-				requires: {
-					type: canSpot
-					filter: culture(gandalf),companion
-				}
+				requires: [
+					{
+						type: canSpot
+						filter: culture(gandalf),companion
+					}
+					{
+						type: not
+						requires: {
+							type: phase
+							phase: fellowship
+						}
+					}
+				]
 				effect: {
 					type: discard
 					player: shadow


### PR DESCRIPTION
This PR stops Brooding on Tomorrow from working during the fellowship phase.

I believe this PR fixes #451 and #408 