### PR TITLE
Fix: Asfaloth affecting only one minion

### DIFF
--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set07/set07-Elven.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set07/set07-Elven.hjson
@@ -126,7 +126,7 @@
 				}
 				effect: {
 					type: modifyStrength
-					select: choose(minion,inSkirmishAgainst(bearer))
+					filter: minion,inSkirmishAgainst(bearer)
 					amount: -2
 				}
 			}


### PR DESCRIPTION
This PR should fix Asfaloth, Elven Steed affecting a single minion instead of all minions skirmishing bearer. 

I believe this fixes #450 