### PR TITLE
Fix: And of Sauron (D) not being random

### DIFF
--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set03/set03-Sauron.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set03/set03-Sauron.hjson
@@ -161,7 +161,7 @@
 				select: choose(culture(sauron),minion)
 			}
 			effect: {
-				type: discardFromHand
+				type: DiscardCardAtRandomFromHand
 				forced: true
 				player: fp
 				hand: fp


### PR DESCRIPTION
This PR should make Decipher's Hand of Sauron's discard random. 

I believe this fixes #442 