### PR TITLE
Fix: Ent Hoard not taking bloom of health modifiers into account

### DIFF
--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set06/set06-Gandalf.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set06/set06-Gandalf.hjson
@@ -193,11 +193,21 @@
 					count: 2
 				}
 			}
+			# These have to be split apart because the spot modifier only works
+			# if a filter has only 1 thing in it
 			{
 				type: modifyOwnCost
 				amount: {
 					type: forEachYouCanSpot
-					filter: or(ent,and(unbound,hobbit))
+					filter: ent
+					multiplier: -2
+				}
+			}
+			{
+				type: modifyOwnCost
+				amount: {
+					type: forEachYouCanSpot
+					filter: unbound,hobbit
 					multiplier: -2
 				}
 			}


### PR DESCRIPTION
This same issue was tackled for Skin Bark and Host of Fanghorn in [this commit](https://github.com/PlayersCouncil/gemp-lotr/commit/478c907dc72b7a46fa999e4ee8c5e8259f11abe5) and for Quickbeam in [this one](https://github.com/PlayersCouncil/gemp-lotr/commit/87cb10bede898a4cdb5556a43c618a6419ead868) but was missed for the biggest boy. 

I believe this fixes #400 and #433