### PR TITLE
Fix: Focus of Power being into the wrong token

### DIFF
--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set07/set07-Gandalf.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set07/set07-Gandalf.hjson
@@ -380,7 +380,7 @@
 				modifier: {
 					type: modifyStrength
 					requires: {
-						type: canSpotThreats
+						type: canSpotTwilight
 						amount: 4
 					}
 					filter: bearer


### PR DESCRIPTION
Gandalf's Staff, Focus of power was triggering off of threat, not twilight, token count. 

I believe this fixes #455 