### PR TITLE
Fix: highestStrength always being 2147483647

### DIFF
--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/filter/FilterFactory.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/filter/FilterFactory.java
@@ -374,7 +374,7 @@ public class FilterFactory {
                                                 new Evaluator() {
                                                     @Override
                                                     public int evaluateExpression(LotroGame game, PhysicalCard cardAffected) {
-                                                        int maxStrength = Integer.MAX_VALUE;
+                                                        int maxStrength = Integer.MIN_VALUE;
                                                         for (PhysicalCard card : Filters.filterActive(game, sourceFilterable))
                                                             maxStrength = Math.max(maxStrength, game.getModifiersQuerying().getStrength(game, card));
                                                         return maxStrength;


### PR DESCRIPTION
@ketura please triple-check me on this one, I am no Java dev so I'm relying on a bunch of Googled documentation to understand how this works.

The `highestStrength` has, what appears to be, a duplication error having been copied from the `lowestStrength` filter (this is conjecture but I believe that's the order of events) where the math check was updated but the initial `int` value was not so this function sets the initial value to the highest integer Java can handle than compares it to each companion's strength choosing the companions strength only if it is higher than Java's maximum integer value of 2147483647. Changing this declaration to be equal to `Integer.MIN_VALUE` should fix the issue (I suspect simply setting it to `0` would also have been sufficient but I'm a stranger here and am trying to stick to the accepted code style). 

I believe this PR fixes #423 