### PR TITLE
Update MemorizeLoser filter function

### DIFF
--- a/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/trigger/WinsSkirmish.java
+++ b/gemp-lotr/gemp-lotr-logic/src/main/java/com/gempukku/lotro/cards/build/field/effect/trigger/WinsSkirmish.java
@@ -50,7 +50,7 @@ public class WinsSkirmish implements TriggerCheckerProducer {
                     if (winner != null) {
                         losers.remove(winner);
                     }
-                    actionContext.setCardMemory(memorizeInvolving, losers);
+                    actionContext.setCardMemory(memorizeLoser, losers);
                 }
                 return result;
             }


### PR DESCRIPTION
I'm feeling a bit outside of my depth here but while investigating #352 I think I've found a code duplication bug that is causing the problem there. It looks like the block for `memorizeInvolving` was copied and modified for `memorizeLoser` but the final param being passed into `actionContext.setCardMemory` was not updated resulting in the filter always passing `null` as the first parameter into that function. This however is where I'm struggling to tell exactly what that effect will result in, I'm trying to dig into the engine but am thus far failing to find the answer and left unsure if this change (while almost certainly needed) will fix #352 or not. 