### PR TITLE
Fix: Eastern Emyn Muil not exerting hard enough

### DIFF
--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set04/set04-Raider.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set04/set04-Raider.hjson
@@ -841,6 +841,7 @@
 				}
 				effect: {
 					type: exert
+					count: 2
 					select: all(ringBound,companion)
 				}
 			}


### PR DESCRIPTION
`Count: 2` was omitted when converted to JSON. 

Fixes #406 