### PR TITLE
Fix: Shingle in the Storm being fashionably late

### DIFF
--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set12/set12-Uruk-hai.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set12/set12-Uruk-hai.hjson
@@ -536,7 +536,7 @@
 			}
 			{
 				type: activated
-				phase: skirmish
+				phase: assignment
 				cost: {
 					type: discard
 					select: self


### PR DESCRIPTION
Shingle in the Storm was incorrectly set to be a skirmish action where it's too late to assign a character. 

Fixes #396 