### PR TITLE
Fix: Faithful companion being a bad Sam

### DIFF
--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/unofficial/pc/errata/set01/set01-Shire-errata.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/unofficial/pc/errata/set01/set01-Shire-errata.hjson
@@ -84,22 +84,34 @@
 		vitality: 4
 		signet: Frodo
 		resistance: 5
-		effects: {
-			type: activated
-			limitPerTurn: 1
-			phase: fellowship
-			cost: {
-				type: exert
-				select: self
+		effects: [
+			{
+				type: activated
+				limitPerTurn: 1
+				phase: fellowship
+				cost: {
+					type: exert
+					select: self
+				}
+				effect: {
+					type: PutCardsFromDeckIntoHand
+					select: choose(culture(shire),item)
+					reveal: true
+					showAll: true
+					shuffle: true
+				}
 			}
-			effect: {
-				type: PutCardsFromDeckIntoHand
-				select: choose(culture(shire),item)
-				reveal: true
-				showAll: true
-				shuffle: true
+			{
+				type: Response
+				trigger: {
+					type: killed
+					filter: name(Frodo),ring bearer
+				}
+				effect: {
+					type: makeSelfRingBearer
+				}
 			}
-		}
+		]
 		gametext: <b>Fellowship:</b> Exert Sam to take a [shire] item into hand from your draw deck (limit once per turn).<br><b>Response:</b> If Frodo dies, make Sam the <b>Ring-bearer (resistance 5)</b>.
 		lore: Mr. Frodo's not going anywhere without me!'
 		promotext: ""


### PR DESCRIPTION
We seem to have removed Sam, Faithful Companion's Samness when we did the most recent PC edit. This PR adds his standard response text back. I did check the other Sams just to be safe but other than the couple in expanded that don't have a take up the one ring clause, it seems Faithful Companion was the only one with the issue. 

Fixes #252 