### PR TITLE
Fix: Lemenya TotO self wounding

### DIFF
--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set10/set10-Ringwraith.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set10/set10-Ringwraith.hjson
@@ -835,7 +835,7 @@
 				}
 				effect: {
 					type: wound
-					select: choose(culture(wraith),minion)
+					select: choose(other,culture(wraith),minion)
 					count: 0-3
 				}
 			}


### PR DESCRIPTION
Lemenya didn't specify other Nazgul for his wounding effect. Fixes #529