### PR TITLE
Fix: Preparations allowing allies to exert

### DIFF
--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set07/set07-Dwarven.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set07/set07-Dwarven.hjson
@@ -530,7 +530,7 @@
 				phase: regroup
 				cost: {
 					type: exert
-					select: choose(dwarf)
+					select: choose(dwarf,companion)
 				}
 				effect: {
 					type: stackCardsFromDiscard


### PR DESCRIPTION
Fixes #582 - Preparations was only limiting the exerting character by race, not by type. 