### PR TITLE
Draft fix - partial

### DIFF
--- a/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/CollectionRequestHandler.java
+++ b/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/CollectionRequestHandler.java
@@ -241,7 +241,10 @@ public class CollectionRequestHandler extends LotroServerRequestHandler implemen
         }
 
         for (var tourney : _tournamentService.getLiveTournaments()) {
-            if(tourney.getInfo().Parameters().type == Tournament.TournamentType.CONSTRUCTED)
+            if (tourney.getInfo().Parameters().type == Tournament.TournamentType.CONSTRUCTED)
+                continue;
+
+            if (!tourney.isPlayerInCompetition(resourceOwner.getName()))
                 continue;
 
             CollectionType collectionType = tourney.getCollectionType();

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -813,9 +813,13 @@ var GempLotrHallUI = Class.extend({
 						}
 						
 						rowhtml += "<td>" + tournament.getAttribute("name") + "</td>" +
-						"<td>" + tournament.getAttribute("system") + "</td>" +
-						"<td>" + tournament.getAttribute("stage") + "</td>" +
-						"<td>" + tournament.getAttribute("round") + "</td>" +
+						"<td>" + tournament.getAttribute("system") + "</td>";
+						if (tournament.hasAttribute("timeRemaining")) {
+						    rowhtml += "<td>" + tournament.getAttribute("stage") + " - " + tournament.getAttribute("timeRemaining") + "</td>";
+						} else {
+						    rowhtml += "<td>" + tournament.getAttribute("stage") + "</td>";
+						}
+						rowhtml += "<td>" + tournament.getAttribute("round") + "</td>" +
 						"<td><div class='prizeHint' title='Competing Players' value='" + tournament.getAttribute("playerList") + "<br><br>* = abandoned'>" + tournament.getAttribute("playerCount") + "</div></td>" +
 						"</tr>";
 						
@@ -843,7 +847,11 @@ var GempLotrHallUI = Class.extend({
                     var tablesRow = $("<tr class='table" + id + "'></tr>");
                     tablesRow.append("<td>" + tournament.getAttribute("format") + "</td>");
                     tablesRow.append("<td> Tournament - " + displayType + " - " + tournament.getAttribute("name") + "</td>");
-                    tablesRow.append("<td>" + tournament.getAttribute("stage") + "</td>");
+                    if (tournament.hasAttribute("timeRemaining")) {
+                        tablesRow.append("<td>" + tournament.getAttribute("stage") + " - " + tournament.getAttribute("timeRemaining") + "</td>");
+                    } else {
+                        tablesRow.append("<td>" + tournament.getAttribute("stage") + "</td>");
+                    }
                     tablesRow.append("<td>" + tournament.getAttribute("playerList") + "</td>");
                     var actionsFieldClone = actionsField.clone(true);
                     tablesRow.append(actionsFieldClone);

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -196,7 +196,7 @@ var GempLotrHallUI = Class.extend({
 				return $(visibilityToggle[index]).hasClass("hidden") ? "0" : "1";
 			};
 
-		var newHallSettings = getSettingValue(0) + "|" + getSettingValue(1) + "|" + getSettingValue(2) + "|" + getSettingValue(3) + "|" + getSettingValue(4)+ "|" + getSettingValue(5) + "|" + getSettingValue(6) + "|" + getSettingValue(7);
+		var newHallSettings = getSettingValue(0) + "|" + getSettingValue(1) + "|" + getSettingValue(2) + "|" + getSettingValue(3) + "|" + getSettingValue(4)+ "|" + getSettingValue(5) + "|" + getSettingValue(6) + "|" + getSettingValue(7) + "|" + getSettingValue(8);
 		console.log("New settings: " + newHallSettings);
 		$.cookie("hallSettings", newHallSettings, { expires:365 });
 	},

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -666,6 +666,7 @@ var GempLotrHallUI = Class.extend({
 				var stage = tournament.getAttribute("stage");
 					if(stage !== null)
 						stage = stage.toLowerCase();
+				var joinable = tournament.getAttribute("joinable") === "true";
 				var abandoned = tournament.getAttribute("abandoned") === "true";
 				if (action == "add" || action == "update") {
 					var actionsField = $("<td></td>");
@@ -763,8 +764,7 @@ var GempLotrHallUI = Class.extend({
 						actionsField.append(but);
 					}
 					else if(!abandoned){
-						if(!(type === "table_draft") && (stage === "deck-building" || stage === "drafting" || stage === "awaiting kickoff"
-						   || stage === "preparing" || stage === "paused between rounds")) {
+						if(joinable) {
 							var but = $("<button>Join Tournament</button>");
 							$(but).button().click((
 								function(tourneyInfo) {

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -858,10 +858,11 @@ var GempLotrHallUI = Class.extend({
 						else {
 							$("table.tournaments", this.tablesDiv)
 							.append(row);
+                            // Display running tournaments also as playing tables
+                            $("table.playingTables", this.tablesDiv)
+                                .append(tablesRow)
 							if (joined == "true") {
-                            // Display joined tournaments also as playing tables
-                                $("table.playingTables", this.tablesDiv)
-                                    .append(tablesRow)
+							    // Open draft window
                                 if ((type === "table_solodraft" && (stage === "deck-building" || stage === "registering decks" || stage === "awaiting kickoff"))
                                 || (type === "table_draft" && stage === "drafting")) {
                                     var tourneyId = tournament.getAttribute("id");
@@ -883,19 +884,14 @@ var GempLotrHallUI = Class.extend({
 						else {
 							$(".tournament" + id, this.tablesDiv).replaceWith(row);
 
-                            // Display joined tournaments also as playing tables
-                            if (joined == "true") {
-                                var existingRow = $(".table" + id, this.tablesDiv);
-                                if (existingRow.length > 0) {
-                                    // If the row exists, replace it
-                                    existingRow.replaceWith(tablesRow);
-                                } else {
-                                    // If the row does not exist, append it
-                                    $("table.playingTables", this.tablesDiv).append(tablesRow);
-                                }
-                            } else if (joined == "false") {
-                                // Remove tournament displayed as playing table
-                                $(".table" + id, this.tablesDiv).remove();
+                            // Display tournaments also as playing tables
+                            var existingRow = $(".table" + id, this.tablesDiv);
+                            if (existingRow.length > 0) {
+                                // If the row exists, replace it
+                                existingRow.replaceWith(tablesRow);
+                            } else {
+                                // If the row does not exist, append it
+                                $("table.playingTables", this.tablesDiv).append(tablesRow);
                             }
 						}
 						

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/chat/ChatRoom.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/chat/ChatRoom.java
@@ -66,6 +66,10 @@ public class ChatRoom {
         }
     }
 
+    public long getSecsSinceLastMessage() {
+        return (System.currentTimeMillis() - _lastMessages.getLast().getWhen().getTime()) / 1000;
+    }
+
     private void shrinkLastMessages() {
         while (_lastMessages.size() > MAX_MESSAGE_HISTORY_COUNT) {
             _lastMessages.removeFirst();

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/chat/ChatRoomMediator.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/chat/ChatRoomMediator.java
@@ -189,4 +189,8 @@ public class ChatRoomMediator {
             _lock.readLock().unlock();
         }
     }
+
+    public long getSecsSinceLastMessage() {
+        return _chatRoom.getSecsSinceLastMessage();
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallCommunicationChannel.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallCommunicationChannel.java
@@ -1,11 +1,13 @@
 package com.gempukku.lotro.hall;
 
+import com.gempukku.lotro.common.DateUtils;
 import com.gempukku.lotro.game.Player;
 import com.gempukku.polling.LongPollableResource;
 import com.gempukku.polling.WaitingRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableObject;
 
+import java.time.Duration;
 import java.util.*;
 
 public class HallCommunicationChannel implements LongPollableResource {
@@ -128,7 +130,8 @@ public class HallCommunicationChannel implements LongPollableResource {
 
                     @Override
                     public void visitTournament(String tournamentKey, String collectionName, String formatName, String tournamentName, String type, String pairingDescription,
-                                                String tournamentStage, int round, int playerCount, String playerList, boolean playerInCompetition, boolean abandoned, boolean joinable) {
+                                                String tournamentStage, int round, int playerCount, String playerList, boolean playerInCompetition, boolean abandoned, boolean joinable,
+                                                long secsRemaining) {
                         Map<String, String> props = new HashMap<>();
                         props.put("collection", collectionName);
                         props.put("format", formatName);
@@ -142,6 +145,9 @@ public class HallCommunicationChannel implements LongPollableResource {
                         props.put("signedUp", String.valueOf(playerInCompetition));
                         props.put("abandoned", String.valueOf(abandoned));
                         props.put("joinable", String.valueOf(joinable));
+                        if (secsRemaining >= 0) {
+                            props.put("timeRemaining", DateUtils.HumanDuration(Duration.ofSeconds(secsRemaining)));
+                        }
 
                         tournamentsOnServer.put(tournamentKey, props);
                     }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallCommunicationChannel.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallCommunicationChannel.java
@@ -128,7 +128,7 @@ public class HallCommunicationChannel implements LongPollableResource {
 
                     @Override
                     public void visitTournament(String tournamentKey, String collectionName, String formatName, String tournamentName, String type, String pairingDescription,
-                                                String tournamentStage, int round, int playerCount, String playerList, boolean playerInCompetition, boolean abandoned) {
+                                                String tournamentStage, int round, int playerCount, String playerList, boolean playerInCompetition, boolean abandoned, boolean joinable) {
                         Map<String, String> props = new HashMap<>();
                         props.put("collection", collectionName);
                         props.put("format", formatName);
@@ -141,6 +141,7 @@ public class HallCommunicationChannel implements LongPollableResource {
                         props.put("playerList", playerList);
                         props.put("signedUp", String.valueOf(playerInCompetition));
                         props.put("abandoned", String.valueOf(abandoned));
+                        props.put("joinable", String.valueOf(joinable));
 
                         tournamentsOnServer.put(tournamentKey, props);
                     }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallInfoVisitor.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallInfoVisitor.java
@@ -18,7 +18,8 @@ public interface HallInfoVisitor {
                                      int readyCheckSecsRemaining, boolean confirmedReadyCheck);
 
     public void visitTournament(String tournamentKey, String collectionName, String formatName, String tournamentName, String type,
-                                String pairingDescription, String tournamentStage, int round, int playerCount, String playerList, boolean playerInCompetition, boolean abandoned, boolean joinable);
+                                String pairingDescription, String tournamentStage, int round, int playerCount, String playerList, boolean playerInCompetition, boolean abandoned, boolean joinable,
+                                long secsRemaining);
 
     public void runningPlayerGame(String gameId);
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallInfoVisitor.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallInfoVisitor.java
@@ -18,7 +18,7 @@ public interface HallInfoVisitor {
                                      int readyCheckSecsRemaining, boolean confirmedReadyCheck);
 
     public void visitTournament(String tournamentKey, String collectionName, String formatName, String tournamentName, String type,
-                                String pairingDescription, String tournamentStage, int round, int playerCount, String playerList, boolean playerInCompetition, boolean abandoned);
+                                String pairingDescription, String tournamentStage, int round, int playerCount, String playerList, boolean playerInCompetition, boolean abandoned, boolean joinable);
 
     public void runningPlayerGame(String gameId);
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallServer.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallServer.java
@@ -917,10 +917,11 @@ public class HallServer extends AbstractServer {
         private HallTournamentCallback(Tournament tournament) {
             tournamentId = tournament.getTournamentId();
             tournamentName = tournament.getTournamentName();
-            // Tournaments with just 2 players can be spectated
-            boolean privateGame = tournament.getPlayersInCompetitionCount() != 2;
+            // Tournaments with no prizes and no entry are not competitive
+            boolean casual = tournament.getInfo().Parameters().prizes == Tournament.PrizeType.NONE
+                            && tournament.getInfo().Parameters().cost == 0;
             tournamentGameSettings = new GameSettings(null, _formatLibrary.getFormat(tournament.getFormatCode()),
-                    tournamentId, null, null, true, privateGame, false,
+                    tournamentId, null, null, !casual, !casual, false,
                     false, GameTimer.TOURNAMENT_TIMER, null);
 
             wcGameSettings = new GameSettings(null, _formatLibrary.getFormat(tournament.getFormatCode()),

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallServer.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallServer.java
@@ -78,7 +78,7 @@ public class HallServer extends AbstractServer {
         _collectionsManager = collectionsManager;
         _adminService = adminService;
 
-        tableHolder = new TableHolder(leagueService, ignoreDAO);
+        tableHolder = new TableHolder(leagueService, tournamentService, ignoreDAO);
 
         _hallChat = _chatServer.createChatRoom("Game Hall", true, 300, true,
                 "You're now in the Game Hall, use /help to get a list of available commands.<br>Don't forget to check out the new Discord chat integration! Click the 'Switch to Discord' button in the lower right ---->",

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/TableHolder.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/TableHolder.java
@@ -251,7 +251,7 @@ public class TableHolder {
 
     private String getTournamentName(GameTable table) {
         final League league = table.getGameSettings().league();
-        final Tournament tournament = tournamentService.getTournamentById(table.getGameSettings().tournamentId());
+        final Tournament tournament = tournamentService.getLiveTournaments().stream().filter(tournament1 -> tournament1.getTournamentId().equals(table.getGameSettings().tournamentId())).findFirst().orElse(null);
         if (league != null) {
             return league.getName() + " - " + table.getGameSettings().leagueSerie().getName();
         } else if (tournament != null) {

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/TableHolder.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/TableHolder.java
@@ -8,11 +8,14 @@ import com.gempukku.lotro.game.Player;
 import com.gempukku.lotro.league.LeagueSerieInfo;
 import com.gempukku.lotro.league.LeagueService;
 import com.gempukku.lotro.logic.vo.LotroDeck;
+import com.gempukku.lotro.tournament.Tournament;
+import com.gempukku.lotro.tournament.TournamentService;
 
 import java.util.*;
 
 public class TableHolder {
     private final LeagueService leagueService;
+    private final TournamentService tournamentService;
     private final IgnoreDAO ignoreDAO;
 
     private final Map<String, GameTable> awaitingTables = new LinkedHashMap<>();
@@ -20,8 +23,9 @@ public class TableHolder {
 
     private int _nextTableId = 1;
 
-    public TableHolder(LeagueService leagueService, IgnoreDAO ignoreDAO) {
+    public TableHolder(LeagueService leagueService, TournamentService tournamentService, IgnoreDAO ignoreDAO) {
         this.leagueService = leagueService;
+        this.tournamentService = tournamentService;
         this.ignoreDAO = ignoreDAO;
     }
 
@@ -247,10 +251,18 @@ public class TableHolder {
 
     private String getTournamentName(GameTable table) {
         final League league = table.getGameSettings().league();
-        if (league != null)
+        final Tournament tournament = tournamentService.getTournamentById(table.getGameSettings().tournamentId());
+        if (league != null) {
             return league.getName() + " - " + table.getGameSettings().leagueSerie().getName();
-        else
+        } else if (tournament != null) {
+            String tournamentTableDescription = tournament.getTableDescription();
+            if (tournamentTableDescription == null || tournamentTableDescription.isEmpty()) {
+                return "Casual - " + table.getGameSettings().timeSettings().name();
+            }
+            return tournamentTableDescription;
+        } else {
             return "Casual - " + table.getGameSettings().timeSettings().name();
+        }
     }
 
     public List<GameTable> getTournamentTables(String tournamentId) {

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/BaseTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/BaseTournament.java
@@ -276,6 +276,14 @@ public abstract class BaseTournament implements Tournament {
             _tournamentService.recordPlayerTournamentAbandon(_tournamentId, player);
             _droppedPlayers.add(player);
             regeneratePlayerList();
+
+            // if last player dropped, finish the tournament
+            Set<String> activePlayers = new HashSet<>(_players);
+            activePlayers.removeAll(_droppedPlayers);
+            if (activePlayers.size() == 0) {
+                finishTournament(null);
+            }
+
             return "You have successfully dropped from the tournament.  Thanks for playing!";
         } finally {
             writeLock.unlock();
@@ -300,7 +308,9 @@ public abstract class BaseTournament implements Tournament {
     protected TournamentProcessAction finishTournament(CollectionsManager collectionsManager) {
         _tournamentInfo.Stage = Stage.FINISHED;
         _tournamentService.recordTournamentStage(_tournamentId, getTournamentStage());
-        awardPrizes(collectionsManager);
+        if (collectionsManager != null) {
+            awardPrizes(collectionsManager);
+        }
         Set<String> activePlayers = new HashSet<>(_players);
         activePlayers.removeAll(_droppedPlayers);
         return new BroadcastAction("Tournament " + getTournamentName() + " is finished.", activePlayers);

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/BaseTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/BaseTournament.java
@@ -128,7 +128,15 @@ public abstract class BaseTournament implements Tournament {
 
         for(var player : _players) {
             if(!_droppedPlayers.contains(player)) {
-                _playerList += player + ", ";
+                _playerList += player;
+                if (!_tournamentInfo._params.requiresDeck) {
+                    // limited game, show who already made a deck
+                    var registeredDeck = getPlayerDeck(player);
+                    if (registeredDeck != null && !StringUtils.isEmpty(registeredDeck.getDeckName())) {
+                        _playerList += "✔";
+                    }
+                }
+                _playerList += ", ";
             }
         }
 
@@ -137,7 +145,10 @@ public abstract class BaseTournament implements Tournament {
         }
 
         if(!_droppedPlayers.isEmpty()) {
-            _playerList += ", " + String.join("*, ", _droppedPlayers);
+            if (!_playerList.isEmpty()) {
+                _playerList += ", ";
+            }
+            _playerList += String.join("*, ", _droppedPlayers);
             if(!_droppedPlayers.isEmpty()) {
                 _playerList += "*";
             }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/BaseTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/BaseTournament.java
@@ -531,4 +531,9 @@ public abstract class BaseTournament implements Tournament {
     public long getSecondsRemaining() throws IllegalStateException{
         throw new IllegalStateException();
     }
+
+    @Override
+    public String getTableDescription() {
+        return null;
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/BaseTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/BaseTournament.java
@@ -7,25 +7,21 @@ import com.gempukku.lotro.common.DateUtils;
 import com.gempukku.lotro.competitive.ModifiedMedianStandingsProducer;
 import com.gempukku.lotro.competitive.PlayerStanding;
 import com.gempukku.lotro.db.vo.CollectionType;
-import com.gempukku.lotro.draft.Draft;
 import com.gempukku.lotro.draft2.SoloDraftDefinitions;
 import com.gempukku.lotro.draft3.TableDraftDefinitions;
 import com.gempukku.lotro.game.CardCollection;
 import com.gempukku.lotro.game.CardNotFoundException;
 import com.gempukku.lotro.game.formats.LotroFormatLibrary;
 import com.gempukku.lotro.hall.TableHolder;
-import com.gempukku.lotro.logic.actions.AbstractCostToEffectAction;
 import com.gempukku.lotro.logic.vo.LotroDeck;
 import com.gempukku.lotro.packs.ProductLibrary;
 import com.gempukku.lotro.tournament.action.BroadcastAction;
 import com.gempukku.lotro.tournament.action.CreateGameAction;
 import com.gempukku.lotro.tournament.action.TournamentProcessAction;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.commons.text.StringEscapeUtils;
 
 import java.time.Duration;
-import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -518,5 +514,10 @@ public abstract class BaseTournament implements Tournament {
             readLock.unlock();
         }
         return _tournamentReport;
+    }
+
+    @Override
+    public long getSecondsRemaining() throws IllegalStateException{
+        throw new IllegalStateException();
     }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/ConstructedTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/ConstructedTournament.java
@@ -127,4 +127,13 @@ public class ConstructedTournament extends BaseTournament implements Tournament 
         //This is for draft only
     }
 
+    @Override
+    public boolean isJoinable() {
+        Set<String> activePlayers = new HashSet<>(_players);
+        activePlayers.removeAll(_droppedPlayers);
+        int maximumPlayers = _tournamentInfo._params.maximumPlayers;
+        return (getTournamentStage() == Tournament.Stage.STARTING || getTournamentStage() == Stage.PREPARING ||
+                getTournamentStage() == Tournament.Stage.PAUSED || getTournamentStage() == Tournament.Stage.AWAITING_KICKOFF)
+                && (maximumPlayers > activePlayers.size() || maximumPlayers < 0);
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SealedTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SealedTournament.java
@@ -238,4 +238,13 @@ public class SealedTournament extends BaseTournament implements Tournament {
         //This is for draft only
     }
 
+    @Override
+    public boolean isJoinable() {
+        Set<String> activePlayers = new HashSet<>(_players);
+        activePlayers.removeAll(_droppedPlayers);
+        int maximumPlayers = _tournamentInfo._params.maximumPlayers;
+        return (getTournamentStage() == Stage.STARTING || getTournamentStage() == Stage.DECK_BUILDING || getTournamentStage() == Stage.DECK_REGISTRATION ||
+                getTournamentStage() == Tournament.Stage.PAUSED || getTournamentStage() == Tournament.Stage.AWAITING_KICKOFF)
+                && (maximumPlayers > activePlayers.size() || maximumPlayers < 0);
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SealedTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SealedTournament.java
@@ -48,16 +48,17 @@ public class SealedTournament extends BaseTournament implements Tournament {
                 _tournamentService.updateRecordedPlayerDeck(_tournamentId, player, deck);
                 _playerDecks.put(player, deck);
 
-                // If 1v1 and both registered the deck, skip the wait and start playing
-                var players = _tournamentService.retrieveTournamentPlayers(_tournamentId);
+                // If all registered the deck, skip the wait and start playing
+                Set<String> activePlayers = new HashSet<>(_players);
+                activePlayers.removeAll(_droppedPlayers);
                 boolean everyoneSubmitted = true;
-                for(var playerName : players) {
+                for(var playerName : activePlayers) {
                     var registeredDeck = getPlayerDeck(playerName);
                     if(registeredDeck == null || StringUtils.isEmpty(registeredDeck.getDeckName())) {
                         everyoneSubmitted = false;
                     }
                 }
-                if (players.size() == 2 && everyoneSubmitted) {
+                if (everyoneSubmitted) {
                     _tournamentInfo.Stage = _sealedInfo.PostRegistrationStage();
                     _tournamentService.recordTournamentStage(_tournamentId, getTournamentStage());
                 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SealedTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SealedTournament.java
@@ -48,6 +48,8 @@ public class SealedTournament extends BaseTournament implements Tournament {
                 _tournamentService.updateRecordedPlayerDeck(_tournamentId, player, deck);
                 _playerDecks.put(player, deck);
 
+                regeneratePlayerList();
+
                 // If all registered the deck, skip the wait and start playing
                 Set<String> activePlayers = new HashSet<>(_players);
                 activePlayers.removeAll(_droppedPlayers);

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SealedTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SealedTournament.java
@@ -267,4 +267,13 @@ public class SealedTournament extends BaseTournament implements Tournament {
             throw new IllegalStateException();
         }
     }
+
+    @Override
+    public String getTableDescription() {
+        if (_sealedInfo._params.prizes == PrizeType.NONE && _sealedInfo._params.cost == 0) {
+            return "Casual - " + _sealedInfo.SealedDefinition.GetName();
+        } else {
+            return "Competitive - " + _sealedInfo.SealedDefinition.GetName();
+        }
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloDraftTournament.java
@@ -252,4 +252,14 @@ public class SoloDraftTournament extends BaseTournament implements Tournament {
     public CollectionType getCollectionType() {
         return _soloDraftInfo.generateCollectionInfo();
     }
+
+    @Override
+    public boolean isJoinable() {
+        Set<String> activePlayers = new HashSet<>(_players);
+        activePlayers.removeAll(_droppedPlayers);
+        int maximumPlayers = _tournamentInfo._params.maximumPlayers;
+        return (getTournamentStage() == Stage.STARTING || getTournamentStage() == Stage.DECK_BUILDING || getTournamentStage() == Stage.DECK_REGISTRATION ||
+                getTournamentStage() == Tournament.Stage.PAUSED || getTournamentStage() == Tournament.Stage.AWAITING_KICKOFF)
+                && (maximumPlayers > activePlayers.size() || maximumPlayers < 0);
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloDraftTournament.java
@@ -51,6 +51,8 @@ public class SoloDraftTournament extends BaseTournament implements Tournament {
                 _tournamentService.updateRecordedPlayerDeck(_tournamentId, player, deck);
                 _playerDecks.put(player, deck);
 
+                regeneratePlayerList();
+
                 // If all registered the deck, skip the wait and start playing
                 Set<String> activePlayers = new HashSet<>(_players);
                 activePlayers.removeAll(_droppedPlayers);

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloDraftTournament.java
@@ -51,16 +51,17 @@ public class SoloDraftTournament extends BaseTournament implements Tournament {
                 _tournamentService.updateRecordedPlayerDeck(_tournamentId, player, deck);
                 _playerDecks.put(player, deck);
 
-                // If 1v1 and both registered the deck, skip the wait and start playing
-                var players = _tournamentService.retrieveTournamentPlayers(_tournamentId);
+                // If all registered the deck, skip the wait and start playing
+                Set<String> activePlayers = new HashSet<>(_players);
+                activePlayers.removeAll(_droppedPlayers);
                 boolean everyoneSubmitted = true;
-                for(var playerName : players) {
+                for(var playerName : activePlayers) {
                     var registeredDeck = getPlayerDeck(playerName);
                     if(registeredDeck == null || StringUtils.isEmpty(registeredDeck.getDeckName())) {
                         everyoneSubmitted = false;
                     }
                 }
-                if (players.size() == 2 && everyoneSubmitted) {
+                if (everyoneSubmitted) {
                     _tournamentInfo.Stage = _soloDraftInfo.PostRegistrationStage();
                     _tournamentService.recordTournamentStage(_tournamentId, getTournamentStage());
                 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloDraftTournament.java
@@ -18,12 +18,15 @@ import com.gempukku.lotro.tournament.action.BroadcastAction;
 import com.gempukku.lotro.tournament.action.TournamentProcessAction;
 import org.apache.commons.lang3.StringUtils;
 
+import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.*;
 
 public class SoloDraftTournament extends BaseTournament implements Tournament {
 
     private static final int HIGH_ENOUGH_PRIME_NUMBER = 8963;
     private SoloDraftTournamentInfo _soloDraftInfo;
+    private ZonedDateTime nextRoundStart = null;
 
     public SoloDraftTournament(TournamentService tournamentService, CollectionsManager collectionsManager, ProductLibrary productLibrary,
                                LotroFormatLibrary formatLibrary, SoloDraftDefinitions soloDraftDefinitions, TableDraftDefinitions tableDraftDefinitions, TableHolder tables, String tournamentId) {
@@ -196,6 +199,7 @@ public class SoloDraftTournament extends BaseTournament implements Tournament {
                         if (_tournamentInfo.PairingMechanism.isFinished(getCurrentRound(), _players, _droppedPlayers)) {
                             result.add(finishTournament(collectionsManager));
                         } else {
+                            nextRoundStart = DateUtils.Now().plus(PairingDelayTime);
                             if(getCurrentRound() == 0) {
                                 result.add(new BroadcastAction("Deck registration for tournament <b>" + getTournamentName()
                                         + "</b> has closed. Round "
@@ -261,5 +265,18 @@ public class SoloDraftTournament extends BaseTournament implements Tournament {
         return (getTournamentStage() == Stage.STARTING || getTournamentStage() == Stage.DECK_BUILDING || getTournamentStage() == Stage.DECK_REGISTRATION ||
                 getTournamentStage() == Tournament.Stage.PAUSED || getTournamentStage() == Tournament.Stage.AWAITING_KICKOFF)
                 && (maximumPlayers > activePlayers.size() || maximumPlayers < 0);
+    }
+
+    @Override
+    public long getSecondsRemaining() throws IllegalStateException {
+        if (getTournamentStage() == Stage.DECK_BUILDING) {
+            return Duration.between(DateUtils.Now(), _soloDraftInfo.DeckbuildingDeadline).getSeconds();
+        } else if (getTournamentStage() == Stage.DECK_REGISTRATION) {
+            return Duration.between(DateUtils.Now(), _soloDraftInfo.RegistrationDeadline).getSeconds();
+        } else if (getTournamentStage() == Stage.PLAYING_GAMES && nextRoundStart != null && DateUtils.Now().isBefore(nextRoundStart)) {
+            return Duration.between(DateUtils.Now(), nextRoundStart).getSeconds();
+        } else {
+            throw new IllegalStateException();
+        }
     }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloDraftTournament.java
@@ -282,4 +282,13 @@ public class SoloDraftTournament extends BaseTournament implements Tournament {
             throw new IllegalStateException();
         }
     }
+
+    @Override
+    public String getTableDescription() {
+        if (_soloDraftInfo._params.prizes == PrizeType.NONE && _soloDraftInfo._params.cost == 0) {
+            return "Casual - " + _soloDraftLibrary.getSoloDraft(_soloDraftInfo._soloDraftParams.soloDraftFormatCode).getCode();
+        } else {
+            return "Competitive - " + _soloDraftLibrary.getSoloDraft(_soloDraftInfo._soloDraftParams.soloDraftFormatCode).getCode();
+        }
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloTableDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloTableDraftTournament.java
@@ -53,16 +53,17 @@ public class SoloTableDraftTournament extends BaseTournament implements Tourname
                 _tournamentService.updateRecordedPlayerDeck(_tournamentId, player, deck);
                 _playerDecks.put(player, deck);
 
-                // If 1v1 and both registered the deck, skip the wait and start playing
-                var players = _tournamentService.retrieveTournamentPlayers(_tournamentId);
+                // If all registered the deck, skip the wait and start playing
+                Set<String> activePlayers = new HashSet<>(_players);
+                activePlayers.removeAll(_droppedPlayers);
                 boolean everyoneSubmitted = true;
-                for(var playerName : players) {
+                for(var playerName : activePlayers) {
                     var registeredDeck = getPlayerDeck(playerName);
                     if(registeredDeck == null || StringUtils.isEmpty(registeredDeck.getDeckName())) {
                         everyoneSubmitted = false;
                     }
                 }
-                if (players.size() == 2 && everyoneSubmitted) {
+                if (everyoneSubmitted) {
                     _tournamentInfo.Stage = soloTableDraftInfo.postRegistrationStage();
                     _tournamentService.recordTournamentStage(_tournamentId, getTournamentStage());
                 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloTableDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloTableDraftTournament.java
@@ -265,4 +265,13 @@ public class SoloTableDraftTournament extends BaseTournament implements Tourname
             throw new IllegalStateException();
         }
     }
+
+    @Override
+    public String getTableDescription() {
+        if (soloTableDraftInfo._params.prizes == PrizeType.NONE && soloTableDraftInfo._params.cost == 0) {
+            return "Casual - " + _tableDraftLibrary.getTableDraftDefinition(soloTableDraftInfo.soloTableDraftParams.soloTableDraftFormatCode).getName();
+        } else {
+            return "Competitive - " + _tableDraftLibrary.getTableDraftDefinition(soloTableDraftInfo.soloTableDraftParams.soloTableDraftFormatCode).getName();
+        }
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloTableDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloTableDraftTournament.java
@@ -16,12 +16,15 @@ import com.gempukku.lotro.tournament.action.BroadcastAction;
 import com.gempukku.lotro.tournament.action.TournamentProcessAction;
 import org.apache.commons.lang3.StringUtils;
 
+import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.*;
 
 public class SoloTableDraftTournament extends BaseTournament implements Tournament {
 
     private SoloTableDraftTournamentInfo soloTableDraftInfo;
     private Map<String, TableDraft> tables = null;
+    private ZonedDateTime nextRoundStart = null;
 
     public SoloTableDraftTournament(TournamentService tournamentService, CollectionsManager collectionsManager, ProductLibrary productLibrary,
                                     LotroFormatLibrary formatLibrary, SoloDraftDefinitions soloDraftDefinitions, TableDraftDefinitions tableDraftDefinitions,
@@ -176,6 +179,7 @@ public class SoloTableDraftTournament extends BaseTournament implements Tourname
                         if (_tournamentInfo.PairingMechanism.isFinished(getCurrentRound(), _players, _droppedPlayers)) {
                             result.add(finishTournament(collectionsManager));
                         } else {
+                            nextRoundStart = DateUtils.Now().plus(PairingDelayTime);
                             if(getCurrentRound() == 0) {
                                 result.add(new BroadcastAction("Deck registration for tournament <b>" + getTournamentName()
                                         + "</b> has closed. Round "
@@ -244,5 +248,18 @@ public class SoloTableDraftTournament extends BaseTournament implements Tourname
         return (getTournamentStage() == Stage.STARTING || getTournamentStage() == Stage.DECK_BUILDING || getTournamentStage() == Stage.DECK_REGISTRATION ||
                 getTournamentStage() == Tournament.Stage.PAUSED || getTournamentStage() == Tournament.Stage.AWAITING_KICKOFF)
                 && (maximumPlayers > activePlayers.size() || maximumPlayers < 0);
+    }
+
+    @Override
+    public long getSecondsRemaining() throws IllegalStateException {
+        if (getTournamentStage() == Stage.DECK_BUILDING) {
+            return Duration.between(DateUtils.Now(), soloTableDraftInfo.deckbuildingDeadline).getSeconds();
+        } else if (getTournamentStage() == Stage.DECK_REGISTRATION) {
+            return Duration.between(DateUtils.Now(), soloTableDraftInfo.registrationDeadline).getSeconds();
+        } else if (getTournamentStage() == Stage.PLAYING_GAMES && nextRoundStart != null && DateUtils.Now().isBefore(nextRoundStart)) {
+            return Duration.between(DateUtils.Now(), nextRoundStart).getSeconds();
+        } else {
+            throw new IllegalStateException();
+        }
     }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloTableDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloTableDraftTournament.java
@@ -235,4 +235,14 @@ public class SoloTableDraftTournament extends BaseTournament implements Tourname
     public CollectionType getCollectionType() {
         return soloTableDraftInfo.generateCollectionInfo();
     }
+
+    @Override
+    public boolean isJoinable() {
+        Set<String> activePlayers = new HashSet<>(_players);
+        activePlayers.removeAll(_droppedPlayers);
+        int maximumPlayers = _tournamentInfo._params.maximumPlayers;
+        return (getTournamentStage() == Stage.STARTING || getTournamentStage() == Stage.DECK_BUILDING || getTournamentStage() == Stage.DECK_REGISTRATION ||
+                getTournamentStage() == Tournament.Stage.PAUSED || getTournamentStage() == Tournament.Stage.AWAITING_KICKOFF)
+                && (maximumPlayers > activePlayers.size() || maximumPlayers < 0);
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloTableDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloTableDraftTournament.java
@@ -53,6 +53,8 @@ public class SoloTableDraftTournament extends BaseTournament implements Tourname
                 _tournamentService.updateRecordedPlayerDeck(_tournamentId, player, deck);
                 _playerDecks.put(player, deck);
 
+                regeneratePlayerList();
+
                 // If all registered the deck, skip the wait and start playing
                 Set<String> activePlayers = new HashSet<>(_players);
                 activePlayers.removeAll(_droppedPlayers);

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TableDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TableDraftTournament.java
@@ -257,4 +257,9 @@ public class TableDraftTournament extends BaseTournament implements Tournament {
     public CollectionType getCollectionType() {
         return tableDraftInfo.generateCollectionInfo();
     }
+
+    @Override
+    public boolean isJoinable() {
+        return false; // cannot join draft in progress
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TableDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TableDraftTournament.java
@@ -59,16 +59,17 @@ public class TableDraftTournament extends BaseTournament implements Tournament {
                 _tournamentService.updateRecordedPlayerDeck(_tournamentId, player, deck);
                 _playerDecks.put(player, deck);
 
-                // If 1v1 and both registered the deck, skip the wait and start playing
-                var players = _tournamentService.retrieveTournamentPlayers(_tournamentId);
+                // If all registered the deck, skip the wait and start playing
+                Set<String> activePlayers = new HashSet<>(_players);
+                activePlayers.removeAll(_droppedPlayers);
                 boolean everyoneSubmitted = true;
-                for(var playerName : players) {
+                for(var playerName : activePlayers) {
                     var registeredDeck = getPlayerDeck(playerName);
                     if(registeredDeck == null || StringUtils.isEmpty(registeredDeck.getDeckName())) {
                         everyoneSubmitted = false;
                     }
                 }
-                if (players.size() == 2 && everyoneSubmitted) {
+                if (everyoneSubmitted) {
                     _tournamentInfo.Stage = tableDraftInfo.postRegistrationStage();
                     _tournamentService.recordTournamentStage(_tournamentId, getTournamentStage());
                 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TableDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TableDraftTournament.java
@@ -199,10 +199,6 @@ public class TableDraftTournament extends BaseTournament implements Tournament {
                     _tournamentInfo.Stage = Stage.PLAYING_GAMES;
                     _tournamentService.recordTournamentStage(_tournamentId, getTournamentStage());
                 } else if (getTournamentStage() == Stage.PLAYING_GAMES) {
-
-                    // Chat room no longer needed - kept alive during deck-building if people stayed longer
-                    chatServer.destroyChatRoom("Draft-" + tableDraftInfo.tableDraftParams.tournamentId);
-
                     if (_currentlyPlayingPlayers.isEmpty()) {
                         if (_tournamentInfo.PairingMechanism.isFinished(getCurrentRound(), _players, _droppedPlayers)) {
                             result.add(finishTournament(collectionsManager));

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TableDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TableDraftTournament.java
@@ -18,6 +18,8 @@ import com.gempukku.lotro.tournament.action.BroadcastAction;
 import com.gempukku.lotro.tournament.action.TournamentProcessAction;
 import org.apache.commons.lang3.StringUtils;
 
+import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.*;
 
 public class TableDraftTournament extends BaseTournament implements Tournament {
@@ -25,6 +27,7 @@ public class TableDraftTournament extends BaseTournament implements Tournament {
     private TableDraftTournamentInfo tableDraftInfo;
     private TableDraft table = null;
     private final ChatServer chatServer;
+    private ZonedDateTime nextRoundStart = null;
 
     public TableDraftTournament(TournamentService tournamentService, CollectionsManager collectionsManager, ProductLibrary productLibrary,
                                 LotroFormatLibrary formatLibrary, SoloDraftDefinitions soloDraftDefinitions, TableDraftDefinitions tableDraftDefinitions,
@@ -201,6 +204,7 @@ public class TableDraftTournament extends BaseTournament implements Tournament {
                         if (_tournamentInfo.PairingMechanism.isFinished(getCurrentRound(), _players, _droppedPlayers)) {
                             result.add(finishTournament(collectionsManager));
                         } else {
+                            nextRoundStart = DateUtils.Now().plus(PairingDelayTime);
                             if(getCurrentRound() == 0) {
                                 result.add(new BroadcastAction("Deck registration for tournament <b>" + getTournamentName()
                                         + "</b> has closed. Round "
@@ -261,5 +265,18 @@ public class TableDraftTournament extends BaseTournament implements Tournament {
     @Override
     public boolean isJoinable() {
         return false; // cannot join draft in progress
+    }
+
+    @Override
+    public long getSecondsRemaining() throws IllegalStateException {
+        if (getTournamentStage() == Stage.DECK_BUILDING) {
+            return Duration.between(DateUtils.Now(), tableDraftInfo.deckbuildingDeadline).getSeconds();
+        } else if (getTournamentStage() == Stage.DECK_REGISTRATION) {
+            return Duration.between(DateUtils.Now(), tableDraftInfo.registrationDeadline).getSeconds();
+        } else if (getTournamentStage() == Stage.PLAYING_GAMES && nextRoundStart != null && DateUtils.Now().isBefore(nextRoundStart)) {
+            return Duration.between(DateUtils.Now(), nextRoundStart).getSeconds();
+        } else {
+            throw new IllegalStateException();
+        }
     }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TableDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TableDraftTournament.java
@@ -59,6 +59,8 @@ public class TableDraftTournament extends BaseTournament implements Tournament {
                 _tournamentService.updateRecordedPlayerDeck(_tournamentId, player, deck);
                 _playerDecks.put(player, deck);
 
+                regeneratePlayerList();
+
                 // If all registered the deck, skip the wait and start playing
                 Set<String> activePlayers = new HashSet<>(_players);
                 activePlayers.removeAll(_droppedPlayers);

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TableDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TableDraftTournament.java
@@ -278,4 +278,13 @@ public class TableDraftTournament extends BaseTournament implements Tournament {
             throw new IllegalStateException();
         }
     }
+
+    @Override
+    public String getTableDescription() {
+        if (tableDraftInfo._params.prizes == PrizeType.NONE && tableDraftInfo._params.cost == 0) {
+            return "Casual - " + _tableDraftLibrary.getTableDraftDefinition(tableDraftInfo.tableDraftParams.tableDraftFormatCode).getName();
+        } else {
+            return "Competitive - " + _tableDraftLibrary.getTableDraftDefinition(tableDraftInfo.tableDraftParams.tableDraftFormatCode).getName();
+        }
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/Tournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/Tournament.java
@@ -207,4 +207,5 @@ public interface Tournament {
 
     boolean isJoinable();
     long getSecondsRemaining() throws IllegalStateException;
+    String getTableDescription();
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/Tournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/Tournament.java
@@ -204,4 +204,6 @@ public interface Tournament {
     String produceReport(DeckRenderer renderer) throws CardNotFoundException;
 
     TournamentInfo getInfo();
+
+    boolean isJoinable();
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/Tournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/Tournament.java
@@ -206,4 +206,5 @@ public interface Tournament {
     TournamentInfo getInfo();
 
     boolean isJoinable();
+    long getSecondsRemaining() throws IllegalStateException;
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
@@ -188,7 +188,7 @@ public class TournamentService {
     public void reloadQueues() {
         _tournamentQueues.clear();
 
-        addImmediateRecurringLimitedGames();
+        addImmediateRecurringCasualLimitedGames();
 
         addImmediateRecurringQueue("fotr_queue", "Fellowship Block", "fotrQueue-", "fotr_block");
         addImmediateRecurringQueue("pc_fotr_queue", "PC-Fellowship", "pcfotrQueue-", "pc_fotr_block");
@@ -213,23 +213,25 @@ public class TournamentService {
         }
     }
 
-    private void addImmediateRecurringLimitedGames() {
+    private void addImmediateRecurringCasualLimitedGames() {
+        String casual = "Casual ";
+
         _tableDraftLibrary.getAllTableDrafts().forEach(tableDraftDefinition -> {
             String code = tableDraftDefinition.getCode();
-            addImmediateRecurringTableDraft(code + "_queue", tableDraftDefinition.getName(), code + "_queue-", code, tableDraftDefinition.getMaxPlayers(), DraftTimerFactory.Type.CLASSIC);
+            addImmediateRecurringTableDraft(code + "_queue", casual + tableDraftDefinition.getName(), code + "_queue-", code, tableDraftDefinition.getMaxPlayers(), DraftTimerFactory.Type.CLASSIC);
         });
 
-        addImmediateRecurringDraft("fotr_solo_draft_queue", "FotR Solo Draft", "fotrSoloDraftQueue-", "fotr_draft");
-        addImmediateRecurringDraft("ttt_solo_draft_queue", "TTT Solo Draft", "tttSoloDraftQueue-", "ttt_draft");
-        addImmediateRecurringDraft("hobbit_solo_draft_queue", "Hobbit Solo Draft", "hobbitSoloDraftQueue-", "hobbit_random_draft");
+        addImmediateRecurringDraft("fotr_solo_draft_queue", casual + "FotR Solo Draft", "fotrSoloDraftQueue-", "fotr_draft");
+        addImmediateRecurringDraft("ttt_solo_draft_queue", casual + "TTT Solo Draft", "tttSoloDraftQueue-", "ttt_draft");
+        addImmediateRecurringDraft("hobbit_solo_draft_queue", casual + "Hobbit Solo Draft", "hobbitSoloDraftQueue-", "hobbit_random_draft");
 
-        addImmediateRecurringSealed("fotr_sealed_queue", "Fellowship Block Sealed", "fotrSealedQueue-", "single_fotr_block_sealed");
-        addImmediateRecurringSealed("ttt_sealed_queue", "Towers Block Sealed", "tttSealedQueue-", "single_ttt_block_sealed");
-        addImmediateRecurringSealed("ts_sealed_queue", "Towers Standard Sealed", "tsSealedQueue-", "single_ts_sealed");
-        addImmediateRecurringSealed("king_sealed_queue", "King Block Sealed", "rotkSealedQueue-", "single_rotk_block_sealed");
-        addImmediateRecurringSealed("movie_sealed_queue", "Movie Sealed", "movieSealedQueue-", "single_movie_sealed");
-        addImmediateRecurringSealed("wotr_sealed_queue", "War of the Ring Block Sealed", "wotrSealedQueue-", "single_wotr_block_sealed");
-        addImmediateRecurringSealed("th_sealed_queue", "Hunters Block Sealed", "thSealedQueue-", "single_th_block_sealed");
+        addImmediateRecurringSealed("fotr_sealed_queue", casual + "Fellowship Block Sealed", "fotrSealedQueue-", "single_fotr_block_sealed");
+        addImmediateRecurringSealed("ttt_sealed_queue", casual + "Towers Block Sealed", "tttSealedQueue-", "single_ttt_block_sealed");
+        addImmediateRecurringSealed("ts_sealed_queue", casual + "Towers Standard Sealed", "tsSealedQueue-", "single_ts_sealed");
+        addImmediateRecurringSealed("king_sealed_queue", casual + "King Block Sealed", "rotkSealedQueue-", "single_rotk_block_sealed");
+        addImmediateRecurringSealed("movie_sealed_queue", casual + "Movie Sealed", "movieSealedQueue-", "single_movie_sealed");
+        addImmediateRecurringSealed("wotr_sealed_queue", casual + "War of the Ring Block Sealed", "wotrSealedQueue-", "single_wotr_block_sealed");
+        addImmediateRecurringSealed("th_sealed_queue", casual + "Hunters Block Sealed", "thSealedQueue-", "single_th_block_sealed");
     }
 
     public void clearCache() {

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
@@ -101,6 +101,7 @@ public class TournamentService {
         sealedParams.name = queueName;
         sealedParams.cost = 0;
         sealedParams.minimumPlayers = 2;
+        sealedParams.maximumPlayers = 2;
         sealedParams.playoff = Tournament.PairingType.SINGLE_ELIMINATION;
         sealedParams.prizes = Tournament.PrizeType.NONE;
 
@@ -128,6 +129,7 @@ public class TournamentService {
         soloDraftParams.name = queueName;
         soloDraftParams.cost = 0;
         soloDraftParams.minimumPlayers = 2;
+        soloDraftParams.maximumPlayers = 2;
         soloDraftParams.playoff = Tournament.PairingType.SINGLE_ELIMINATION;
         soloDraftParams.prizes = Tournament.PrizeType.NONE;
 
@@ -265,7 +267,8 @@ public class TournamentService {
             visitor.visitTournament(tourneyID, tournament.getCollectionType().getFullName(),
                     formatLibrary.getFormat(tournament.getFormatCode()).getName(), tournament.getTournamentName(), tournament.getInfo().Parameters().type.toString(), tournament.getPlayOffSystem(),
                     tournament.getTournamentStage().getHumanReadable(),
-                    tournament.getCurrentRound(), tournament.getPlayersInCompetitionCount(), tournament.getPlayerList(), tournament.isPlayerInCompetition(player.getName()), tournament.isPlayerAbandoned(player.getName()));
+                    tournament.getCurrentRound(), tournament.getPlayersInCompetitionCount(), tournament.getPlayerList(), tournament.isPlayerInCompetition(player.getName()), tournament.isPlayerAbandoned(player.getName()),
+                    tournament.isJoinable());
         }
 
     }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
@@ -264,11 +264,17 @@ public class TournamentService {
         for (var entry : _activeTournaments.entrySet()) {
             var tourneyID = entry.getKey();
             var tournament = entry.getValue();
+            long secsRemaining = -1;
+            try {
+                secsRemaining = tournament.getSecondsRemaining();
+            } catch (IllegalStateException ignore) {
+
+            }
             visitor.visitTournament(tourneyID, tournament.getCollectionType().getFullName(),
                     formatLibrary.getFormat(tournament.getFormatCode()).getName(), tournament.getTournamentName(), tournament.getInfo().Parameters().type.toString(), tournament.getPlayOffSystem(),
                     tournament.getTournamentStage().getHumanReadable(),
                     tournament.getCurrentRound(), tournament.getPlayersInCompetitionCount(), tournament.getPlayerList(), tournament.isPlayerInCompetition(player.getName()), tournament.isPlayerAbandoned(player.getName()),
-                    tournament.isJoinable());
+                    tournament.isJoinable(), secsRemaining);
         }
 
     }


### PR DESCRIPTION
- Fixes #621 
- Fixes visibility of 'Active Tournaments' section in hall not being saved to cookie
- Removes ability to late join to 1v1 tournaments (solo draft and sealed)
- Added all running tournaments to 'Playing Tables' section for all players to promote visibility
- Tournaments with no active players (all dropped) finish early without waiting for timer
- Tournaments with no entry, no prizes, no wc id (casual tournaments) can be spectated and chat can be used by spectators
- Added timers for deck-building, deck registration and tournament pairing delay to game hall

This **does not** fix issue #620 as i was unable to reproduce that bug in my local docker. Hopefully the added timer will help with debugging. Can you try that on playtest server? Join table draft, request start as solo player, click random cards til draft ends, look at the timer next to 'deck-building' stage, it should be 15 minutes. If it is 15 minutes, wait and see if the next stage triggers (it should then move to registration for 2 minutes and then kick you out because of no deck)

Edit with some new stuff:
- Made a workaround that allows games with multiple players to start - when all players submit a deck, games start without relying on the broken timer - this is a temp fix because if one player leaves after draft without abandoning the tournament, the timer will not remove them - but it does allow full tables to draft and play afterwards
- Added a checkmark icon to indicate which players have registered a deck and which players have not
- Fixed draft chat rooms not being destroyed when tournament finishes because all players left - chat server now cleans up the rooms automatically when they are not used instead of tournament manually calling to have them removed
- Added nicer name for tournament playing tables instead of 'casual - tournament'
- All limited tournament names start with 'Casual' now to contribute to casual statistics

![image](https://github.com/user-attachments/assets/9f3266e4-a8a4-4ffc-9ffd-64ae18ce2e8c)
