### PR TITLE
Fixed - broken draft timers

### DIFF
--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TableDraftTournamentInfo.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TableDraftTournamentInfo.java
@@ -15,9 +15,7 @@ import java.time.ZonedDateTime;
 public class TableDraftTournamentInfo extends TournamentInfo {
 
     public final TableDraftDefinition tableDraftDefinition;
-    public ZonedDateTime deckbuildingDeadline;
     public final Duration deckbuildingDuration;
-    public ZonedDateTime registrationDeadline;
     public final Duration registrationDuration;
     protected TableDraftTournamentParams tableDraftParams;
 
@@ -30,9 +28,6 @@ public class TableDraftTournamentInfo extends TournamentInfo {
 
         deckbuildingDuration = Duration.ofMinutes(tableDraftParams.deckbuildingDuration);
         registrationDuration = Duration.ofMinutes(tableDraftParams.turnInDuration);
-//
-        deckbuildingDeadline = StartTime.plus(deckbuildingDuration);
-//        registrationDeadline = deckbuildingDeadline.plus(registrationDuration);
     }
 
     //Used by tournament queues to duplicate a template info with fresh parameters


### PR DESCRIPTION
Fixes #620 

The timers got refreshed by loading tournament info from database -> moved deadlines from tournament info to tournament class. Non-table tournaments do not have this issue because their timers are based on tournament start time, table draft timer is based on the end of draft.