### PR TITLE
Tournament db optimization

### DIFF
--- a/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/AdminRequestHandler.java
+++ b/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/AdminRequestHandler.java
@@ -1183,7 +1183,6 @@ public class AdminRequestHandler extends LotroServerRequestHandler implements Ur
 
     private void clearCacheInternal() throws SQLException, IOException {
         _leagueService.clearCache();
-        _tournamentService.clearCache();
         _cacheManager.clearCaches();
         _hallServer.cleanup(true);
     }

--- a/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TableDraftRequestHandler.java
+++ b/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TableDraftRequestHandler.java
@@ -8,10 +8,8 @@ import com.gempukku.lotro.draft2.SoloDraftDefinitions;
 import com.gempukku.lotro.draft3.DraftPlayer;
 import com.gempukku.lotro.draft3.TableDraft;
 import com.gempukku.lotro.draft3.TableDraftDefinitions;
-import com.gempukku.lotro.game.CardCollection;
 import com.gempukku.lotro.game.LotroCardBlueprintLibrary;
 import com.gempukku.lotro.game.Player;
-import com.gempukku.lotro.game.SortAndFilterCards;
 import com.gempukku.lotro.game.formats.LotroFormatLibrary;
 import com.gempukku.lotro.league.LeagueService;
 import com.gempukku.lotro.packs.ProductLibrary;
@@ -25,15 +23,10 @@ import io.netty.handler.codec.http.QueryStringDecoder;
 import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.lang.reflect.Type;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class TableDraftRequestHandler extends LotroServerRequestHandler implements UriRequestHandler {

--- a/gemp-lotr/gemp-lotr-async/src/main/web/includes/admin/generalAdmin.html
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/includes/admin/generalAdmin.html
@@ -24,7 +24,18 @@
 						$("#shutdown-response").html(string);
 					});
 				});
-			
+
+			hall.comm.getLiveTournaments(
+				function (xml) {
+					var root = xml.documentElement;
+					if (root.tagName == 'tournaments') {
+						var tournaments = root.getElementsByTagName("tournament");
+						if (tournaments.length > 0) {
+							$("#cache-response").html("Ready.<br>Live tournaments: " + tournaments.length + "<br>THE ABOVE TOURNAMENTS WILL BE INTERRUPTED AND MAY NOT BE ABLE TO BE RESUMED");
+						}
+					}
+            	});
+
 			$("#clear-cache-button").button().click(
 				function () {
 					$("#cache-response").html("Processing...");

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/collection/CollectionsManager.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/collection/CollectionsManager.java
@@ -135,6 +135,16 @@ public class CollectionsManager {
         }
     }
 
+
+    public void removeFromPlayerCollection(String player, String collectionType, CardCollection cardCollection, String reason) throws SQLException, IOException {
+        _readWriteLock.writeLock().lock();
+        try {
+            removeFromPlayerCollection(_playerDAO.getPlayer(player), collectionType, cardCollection, reason);
+        } finally {
+            _readWriteLock.writeLock().unlock();
+        }
+    }
+
     private void removeFromPlayerCollection(Player player, String collectionType, CardCollection cardCollection, String reason) {
         if (collectionType.contains("+"))
             throw new IllegalArgumentException("Invalid collection type: " + collectionType);
@@ -306,10 +316,6 @@ public class CollectionsManager {
         } finally {
             _readWriteLock.writeLock().unlock();
         }
-    }
-
-    public boolean sellCardInPlayerCollection(String player, CollectionType collectionType, String blueprintId, int currency) throws SQLException, IOException {
-        return sellCardInPlayerCollection(_playerDAO.getPlayer(player), collectionType, blueprintId, currency);
     }
 
     public boolean sellCardInPlayerCollection(Player player, CollectionType collectionType, String blueprintId, int currency) throws SQLException, IOException {

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/draft3/TableDraftClassic.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/draft3/TableDraftClassic.java
@@ -164,11 +164,7 @@ public class TableDraftClassic implements TableDraft{
                     if (draftPlayer instanceof DraftBot) {
                         botCollections.remove(draftPlayer);
                     } else {
-                        for (CardCollection.Item item : collection.getAll()) {
-                            for (int i = 0; i < item.getCount(); i++) {
-                                collectionsManager.sellCardInPlayerCollection(draftPlayer.getName(), collectionType, item.getBlueprintId(), 0);
-                            }
-                        }
+                        collectionsManager.removeFromPlayerCollection(draftPlayer.getName(), collectionType.getCode(), collection, "Duplicate tournament collection");
                     }
                 }
             } catch (SQLException | IOException ignore) {

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/TableHolder.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/TableHolder.java
@@ -268,18 +268,16 @@ public class TableHolder {
 
     private String getTournamentName(GameTable table) {
         final League league = table.getGameSettings().league();
-        final Tournament tournament = null; //tournamentService.getLiveTournaments().stream().filter(tournament1 -> tournament1.getTournamentId().equals(table.getGameSettings().tournamentId())).findFirst().orElse(null);
         if (league != null) {
             return league.getName() + " - " + table.getGameSettings().leagueSerie().getName();
-        } else if (tournament != null) {
-            String tournamentTableDescription = tournament.getTableDescription();
-            if (tournamentTableDescription == null || tournamentTableDescription.isEmpty()) {
-                return "Casual - " + table.getGameSettings().timeSettings().name();
+        } else if (table.getGameSettings().tournamentId() != null) {
+            final String tournamentTableDescription = tournamentService.getActiveTournamentTableDescription(table.getGameSettings().tournamentId());
+            if (tournamentTableDescription != null) {
+                return tournamentTableDescription;
             }
-            return tournamentTableDescription;
-        } else {
-            return "Casual - " + table.getGameSettings().timeSettings().name();
         }
+
+        return "Casual - " + table.getGameSettings().timeSettings().name();
     }
 
     public List<GameTable> getTournamentTables(String tournamentId) {

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SealedTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SealedTournament.java
@@ -25,6 +25,8 @@ public class SealedTournament extends BaseTournament implements Tournament {
     private SealedTournamentInfo _sealedInfo;
     private ZonedDateTime nextRoundStart = null;
 
+    private boolean collectionsCreated = false;
+
     public SealedTournament(TournamentService tournamentService, CollectionsManager collectionsManager, ProductLibrary productLibrary,
                             LotroFormatLibrary formatLibrary, SoloDraftDefinitions soloDraftDefinitions, TableDraftDefinitions tableDraftDefinitions, TableHolder tables, String tournamentId) {
         super(tournamentService, collectionsManager, productLibrary, formatLibrary, soloDraftDefinitions, tableDraftDefinitions, tables, tournamentId);
@@ -90,7 +92,11 @@ public class SealedTournament extends BaseTournament implements Tournament {
         _collectionsManager.addPlayerCollection(true, "Sealed tournament product", player, collDef, newCollection);
     }
 
-    public void createAndPopulateCollections() {
+    private void createAndPopulateCollections() {
+        if (collectionsCreated) {
+            return;
+        }
+
         var collDef = _sealedInfo.generateCollectionInfo();
         var collections = _collectionsManager.getPlayersCollection(collDef.getCode());
         var sealedDef = _sealedInfo.SealedDefinition;
@@ -107,6 +113,8 @@ public class SealedTournament extends BaseTournament implements Tournament {
 
             _collectionsManager.addPlayerCollection(true, "Sealed tournament product", playerName, collDef, newCollection);
         }
+
+        collectionsCreated = true;
     }
 
     public void disqualifyUnregisteredPlayers() {
@@ -169,6 +177,8 @@ public class SealedTournament extends BaseTournament implements Tournament {
                 if(getTournamentStage() == Stage.STARTING) {
                     _tournamentInfo.Stage = Stage.DECK_BUILDING;
                     _tournamentService.recordTournamentStage(_tournamentId, getTournamentStage());
+
+                    createAndPopulateCollections();
 
                     String duration = DateUtils.HumanDuration(_sealedInfo.DeckbuildingDuration);
                     result.add(new BroadcastAction("Sealed product has been issued for tournament <b>" + getTournamentName() + "</b>.  Players now have "

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloDraftTournament.java
@@ -28,6 +28,8 @@ public class SoloDraftTournament extends BaseTournament implements Tournament {
     private SoloDraftTournamentInfo _soloDraftInfo;
     private ZonedDateTime nextRoundStart = null;
 
+    private boolean collectionsCreated = false;
+
     public SoloDraftTournament(TournamentService tournamentService, CollectionsManager collectionsManager, ProductLibrary productLibrary,
                                LotroFormatLibrary formatLibrary, SoloDraftDefinitions soloDraftDefinitions, TableDraftDefinitions tableDraftDefinitions, TableHolder tables, String tournamentId) {
         super(tournamentService, collectionsManager, productLibrary, formatLibrary, soloDraftDefinitions, tableDraftDefinitions, tables, tournamentId);
@@ -112,6 +114,10 @@ public class SoloDraftTournament extends BaseTournament implements Tournament {
     }
 
     private void createStartingCollections() {
+        if (collectionsCreated) {
+            return;
+        }
+
         var collDef = _soloDraftInfo.generateCollectionInfo();
         var collections = _collectionsManager.getPlayersCollection(collDef.getCode());
 
@@ -134,6 +140,8 @@ public class SoloDraftTournament extends BaseTournament implements Tournament {
 
             _collectionsManager.addPlayerCollection(false, "Draft tournament product", playerName, collDef, startingCollection);
         }
+
+        collectionsCreated = true;
     }
 
     private long getSeed(String playerName, CollectionType collectionType) {


### PR DESCRIPTION
Proper fix of that tournament name spam hotfix -> accepting this PR will allow nice table names again and reduce the number of db queries

- Greatly reduced the number of db queries which ask for live tournaments
- Also reduced the number of collection related queries related to card removal from collection if draft with the same id starts (should not happen often but since i was already thinking about db optimization...)
- Fixed a bug in sealed tournament caused by reducing the number of said queries - quick testing have not revealed any other problems 

This also probably fixes #620 , but i would still suggest accepting also #629 which solves that 100 %