### PR TITLE
Limited deck validation + tournament ids modification

### DIFF
--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/communication.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/communication.js
@@ -612,7 +612,7 @@ var GempLotrCommunication = Class.extend({
             dataType:"xml"
         });
     },
-    getDeckStats:function (contents, targetFormat, callback, errorMap) {
+    getDeckStats:function (contents, targetFormat, collectionName, callback, errorMap) {
         $.ajax({
             type:"POST",
             url:this.url + "/deck/stats",
@@ -620,6 +620,7 @@ var GempLotrCommunication = Class.extend({
             data:{
                 participantId:getUrlParam("participantId"),
                 targetFormat:targetFormat,
+                collectionName:collectionName,
                 deckContents:contents},
             success:this.deckbuilderDeliveryCheck(callback),
             error:this.errorCheck(errorMap),

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/deckBuildingUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/deckBuildingUi.js
@@ -336,6 +336,10 @@ var GempLotrDeckBuildingUI = Class.extend({
 				that.updateDeckStats();
 			}
 		}, this.checkDirtyInterval);
+
+		$("#formatSelect").change(function () {
+				that.deckValidationDirty = true;
+        });
 		
 		this.updateFormatOptions();
 		this.comm.forcePackDelivery();
@@ -458,7 +462,10 @@ var GempLotrDeckBuildingUI = Class.extend({
 					for (var i = 0; i < collections.length; i++) {
 						var collection = collections[i];
 						$("#collectionSelect").append("<option value='" + collection.getAttribute("type") + "'>" + collection.getAttribute("name") + "</option>");
-						$("#formatSelect").append("<option value='" + collection.getAttribute("format") + "'>" + collection.getAttribute("name") + "</option>");
+						$("#formatSelect").append(
+                          "<option value='" + collection.getAttribute("format") + "' data-type='" + collection.getAttribute("type") + "'>" +
+                          collection.getAttribute("name") + "</option>"
+                        );
 					}
 					
 					$("#collectionSelect").val("default");
@@ -1055,11 +1062,13 @@ var GempLotrDeckBuildingUI = Class.extend({
 
 	updateDeckStats:function () {
 		var that = this;
+		var selectedOption = $("#formatSelect option:selected");
 		var deckContents = this.getDeckContents();
 		if (deckContents != null && deckContents != "") 
 		{
 			this.comm.getDeckStats(deckContents, 
-				  $("#formatSelect").val(),
+				  selectedOption.val(), // format
+				  selectedOption.data("type"), // collection name
 					function (html) 
 					{
 						$("#deckStats").html(html);
@@ -1094,6 +1103,7 @@ var GempLotrDeckBuildingUI = Class.extend({
 						
 						var option = $("<option/>")
 							.attr("value", code)
+							.attr("data-type", "default") // default collection for non-limited formats
 							.text(format.name);
 						options[format.order] = option;
 						if(format.order > max) {

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/deckBuildingUi2.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/deckBuildingUi2.js
@@ -935,6 +935,7 @@ var GempLotrDeckBuildingUI = Class.extend({
         {
             this.comm.getDeckStats(deckContents, 
                    $("#formatSelect").val(),
+                   "default", // TODO - collection name for limited formats, now it does not check card availability
                     function (html) 
                     {
                         $("#deckStats").html(html);

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
@@ -188,13 +188,13 @@ public class TournamentService {
 
         addImmediateRecurringCasualLimitedGames();
 
-        addImmediateRecurringQueue("fotr_queue", "Fellowship Block", "fotrQueue-", "fotr_block");
-        addImmediateRecurringQueue("pc_fotr_queue", "PC-Fellowship", "pcfotrQueue-", "pc_fotr_block");
-        addImmediateRecurringQueue("ts_queue", "Towers Standard", "tsQueue-", "towers_standard");
-        addImmediateRecurringQueue("movie_queue", "Movie Block", "movieQueue-", "movie");
-        addImmediateRecurringQueue("pc_movie_queue", "PC-Movie", "pcmovieQueue-", "pc_movie");
-        addImmediateRecurringQueue("expanded_queue", "Expanded", "expandedQueue-", "expanded");
-        addImmediateRecurringQueue("pc_expanded_queue", "PC-Expanded", "pcexpandedQueue-", "pc_expanded");
+        addImmediateRecurringQueue("fotr_queue", "Fellowship Block", "fotr-", "fotr_block");
+        addImmediateRecurringQueue("pc_fotr_queue", "PC-Fellowship", "pcfotr-", "pc_fotr_block");
+        addImmediateRecurringQueue("ts_queue", "Towers Standard", "ts-", "towers_standard");
+        addImmediateRecurringQueue("movie_queue", "Movie Block", "movie-", "movie");
+        addImmediateRecurringQueue("pc_movie_queue", "PC-Movie", "pcmovie-", "pc_movie");
+        addImmediateRecurringQueue("expanded_queue", "Expanded", "expanded-", "expanded");
+        addImmediateRecurringQueue("pc_expanded_queue", "PC-Expanded", "pcexpanded-", "pc_expanded");
 
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
@@ -216,20 +216,20 @@ public class TournamentService {
 
         _tableDraftLibrary.getAllTableDrafts().forEach(tableDraftDefinition -> {
             String code = tableDraftDefinition.getCode();
-            addImmediateRecurringTableDraft(code + "_queue", casual + tableDraftDefinition.getName(), code + "_queue-", code, tableDraftDefinition.getMaxPlayers(), DraftTimerFactory.Type.CLASSIC);
+            addImmediateRecurringTableDraft(code + "_queue", casual + tableDraftDefinition.getName(), code + "-", code, tableDraftDefinition.getMaxPlayers(), DraftTimerFactory.Type.CLASSIC);
         });
 
-        addImmediateRecurringDraft("fotr_solo_draft_queue", casual + "FotR Solo Draft", "fotrSoloDraftQueue-", "fotr_draft");
-        addImmediateRecurringDraft("ttt_solo_draft_queue", casual + "TTT Solo Draft", "tttSoloDraftQueue-", "ttt_draft");
-        addImmediateRecurringDraft("hobbit_solo_draft_queue", casual + "Hobbit Solo Draft", "hobbitSoloDraftQueue-", "hobbit_random_draft");
+        addImmediateRecurringDraft("fotr_solo_draft_queue", casual + "FotR Solo Draft", "fotrSoloDraft-", "fotr_draft");
+        addImmediateRecurringDraft("ttt_solo_draft_queue", casual + "TTT Solo Draft", "tttSoloDraft-", "ttt_draft");
+        addImmediateRecurringDraft("hobbit_solo_draft_queue", casual + "Hobbit Solo Draft", "hobbitSoloDraft-", "hobbit_random_draft");
 
-        addImmediateRecurringSealed("fotr_sealed_queue", casual + "Fellowship Block Sealed", "fotrSealedQueue-", "single_fotr_block_sealed");
-        addImmediateRecurringSealed("ttt_sealed_queue", casual + "Towers Block Sealed", "tttSealedQueue-", "single_ttt_block_sealed");
-        addImmediateRecurringSealed("ts_sealed_queue", casual + "Towers Standard Sealed", "tsSealedQueue-", "single_ts_sealed");
-        addImmediateRecurringSealed("king_sealed_queue", casual + "King Block Sealed", "rotkSealedQueue-", "single_rotk_block_sealed");
-        addImmediateRecurringSealed("movie_sealed_queue", casual + "Movie Sealed", "movieSealedQueue-", "single_movie_sealed");
-        addImmediateRecurringSealed("wotr_sealed_queue", casual + "War of the Ring Block Sealed", "wotrSealedQueue-", "single_wotr_block_sealed");
-        addImmediateRecurringSealed("th_sealed_queue", casual + "Hunters Block Sealed", "thSealedQueue-", "single_th_block_sealed");
+        addImmediateRecurringSealed("fotr_sealed_queue", casual + "Fellowship Block Sealed", "fotrSealed-", "single_fotr_block_sealed");
+        addImmediateRecurringSealed("ttt_sealed_queue", casual + "Towers Block Sealed", "tttSealed-", "single_ttt_block_sealed");
+        addImmediateRecurringSealed("ts_sealed_queue", casual + "Towers Standard Sealed", "tsSealed-", "single_ts_sealed");
+        addImmediateRecurringSealed("king_sealed_queue", casual + "King Block Sealed", "rotkSealed-", "single_rotk_block_sealed");
+        addImmediateRecurringSealed("movie_sealed_queue", casual + "Movie Sealed", "movieSealed-", "single_movie_sealed");
+        addImmediateRecurringSealed("wotr_sealed_queue", casual + "War of the Ring Block Sealed", "wotrSealed-", "single_wotr_block_sealed");
+        addImmediateRecurringSealed("th_sealed_queue", casual + "Hunters Block Sealed", "thSealed-", "single_th_block_sealed");
     }
 
     public void cancelAllTournamentQueues() throws SQLException, IOException {


### PR DESCRIPTION
- Resolves #639 

Tested manually with:
- sealed 1v1
- table draft tournament
- solo draft league
- constructed format to ensure it does not break

Also fixed by this: tournament ids do not contain 'queue' anymore (noticed this now since their collection names contained it)


![image](https://github.com/user-attachments/assets/853543a4-2535-4e36-a398-09cabf5688ec)


