### PR TITLE
WC queues/tournaments refactoring

### DIFF
--- a/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/AdminRequestHandler.java
+++ b/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/AdminRequestHandler.java
@@ -982,7 +982,7 @@ public class AdminRequestHandler extends LotroServerRequestHandler implements Ur
         int minPlayers = Throw400IfNullOrNonInteger("minPlayers", minPlayersStr);
         boolean manualKickoff = ParseBoolean("manualKickoff", manualKickoffStr, false);
 
-        if(wc) {
+        if (wc) {
             tournamentId = DateUtils.Now().getYear() + "-wc-" + tournamentId;
         }
 
@@ -1070,6 +1070,10 @@ public class AdminRequestHandler extends LotroServerRequestHandler implements Ur
         params.prizes = Tournament.PrizeType.DAILY;
         params.minimumPlayers = minPlayers;
         params.manualKickoff = manualKickoff;
+
+        if (wc) {
+            params.wc = true;
+        }
 
         TournamentInfo info;
 

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -404,7 +404,7 @@ var GempLotrHallUI = Class.extend({
 			for (var i = 0; i < queues.length; i++) {
 				var queue = queues[i];
 				var id = queue.getAttribute("id");
-				var isWC = id.toLowerCase().includes("wc");
+				var isWC = queue.getAttribute("wc") == "true";
 				var action = queue.getAttribute("action");
 				if (action == "add" || action == "update") {
 					var actionsField = $("<td></td>");
@@ -660,7 +660,7 @@ var GempLotrHallUI = Class.extend({
 			for (var i = 0; i < tournaments.length; i++) {
 				var tournament = tournaments[i];
 				var id = tournament.getAttribute("id");
-				var isWC = id.toLowerCase().includes("wc");
+				var isWC = tournament.getAttribute("wc") == "true";
 				var action = tournament.getAttribute("action");
 				var type = tournament.getAttribute("type");
 				if(type !== null)

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -965,11 +965,6 @@ var GempLotrHallUI = Class.extend({
 					}
 					
 					name += "</td>";
-					
-					//TODO: Replace this with an actual fix on the server side 
-					if(name.includes("Casual - WC")) {
-						name = "<td><b>2024 World Championship" + userDesc + "</b></td>"
-					}
 					row.append(name);
 					row.append("<td>" + statusDescription + "</td>");
 

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/db/DbTournamentDAO.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/db/DbTournamentDAO.java
@@ -222,10 +222,12 @@ public class DbTournamentDAO implements TournamentDAO {
                     SELECT id, tournament_id, name, format, start_date, type, parameters, started
                     FROM scheduled_tournament
                     WHERE started = 0
-                        AND start_date <= :start;
+                        AND start_date <= :start
+                        AND start_date >= :now;
                         """;
                 List<DBDefs.ScheduledTournament> result = conn.createQuery(sql)
                         .addParameter("start", tillDate)
+                        .addParameter("now", ZonedDateTime.now())
                         .executeAndFetch(DBDefs.ScheduledTournament.class);
 
                 return result;

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallCommunicationChannel.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallCommunicationChannel.java
@@ -107,7 +107,7 @@ public class HallCommunicationChannel implements LongPollableResource {
                     @Override
                     public void visitTournamentQueue(String tournamentQueueKey, int cost, String collectionName, String formatName, String type, String tournamentQueueName,
                                                      String tournamentPrizes, String pairingDescription, String startCondition, int playerCount, String playerList, boolean playerSignedUp,
-                                                     boolean joinable, boolean startable, int readyCheckSecsRemaining, boolean confirmedReadyCheck) {
+                                                     boolean joinable, boolean startable, int readyCheckSecsRemaining, boolean confirmedReadyCheck, boolean wc) {
                         Map<String, String> props = new HashMap<>();
                         props.put("cost", String.valueOf(cost));
                         props.put("collection", collectionName);
@@ -124,6 +124,7 @@ public class HallCommunicationChannel implements LongPollableResource {
                         props.put("startable", String.valueOf(startable));
                         props.put("readyCheckSecsRemaining", String.valueOf(readyCheckSecsRemaining));
                         props.put("confirmedReadyCheck", String.valueOf(confirmedReadyCheck));
+                        props.put("wc", String.valueOf(wc));
                         if (tournamentQueueKey.contains("table")) {
                             props.put("draftCode", tournamentQueueKey.replace("_queue", ""));
                         }
@@ -134,7 +135,7 @@ public class HallCommunicationChannel implements LongPollableResource {
                     @Override
                     public void visitTournament(String tournamentKey, String collectionName, String formatName, String tournamentName, String type, String pairingDescription,
                                                 String tournamentStage, int round, int playerCount, String playerList, boolean playerInCompetition, boolean abandoned, boolean joinable,
-                                                long secsRemaining) {
+                                                long secsRemaining, boolean wc) {
                         Map<String, String> props = new HashMap<>();
                         props.put("collection", collectionName);
                         props.put("format", formatName);
@@ -148,6 +149,7 @@ public class HallCommunicationChannel implements LongPollableResource {
                         props.put("signedUp", String.valueOf(playerInCompetition));
                         props.put("abandoned", String.valueOf(abandoned));
                         props.put("joinable", String.valueOf(joinable));
+                        props.put("wc", String.valueOf(wc));
                         if (secsRemaining >= 0) {
                             props.put("timeRemaining", DateUtils.HumanDuration(Duration.ofSeconds(secsRemaining)));
                         }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallInfoVisitor.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallInfoVisitor.java
@@ -15,11 +15,11 @@ public interface HallInfoVisitor {
 
     public void visitTournamentQueue(String tournamentQueueKey, int cost, String collectionName, String formatName, String type, String tournamentQueueName, String tournamentPrizes,
                                      String pairingDescription, String startCondition, int playerCount, String playerList, boolean playerSignedUp, boolean joinable, boolean startable,
-                                     int readyCheckSecsRemaining, boolean confirmedReadyCheck);
+                                     int readyCheckSecsRemaining, boolean confirmedReadyCheck, boolean wc);
 
     public void visitTournament(String tournamentKey, String collectionName, String formatName, String tournamentName, String type,
                                 String pairingDescription, String tournamentStage, int round, int playerCount, String playerList, boolean playerInCompetition, boolean abandoned, boolean joinable,
-                                long secsRemaining);
+                                long secsRemaining, boolean wc);
 
     public void runningPlayerGame(String gameId);
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/AbstractTournamentQueue.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/AbstractTournamentQueue.java
@@ -395,4 +395,9 @@ public abstract class AbstractTournamentQueue implements TournamentQueue {
             readyCheckTask = null;
         }
     }
+
+    @Override
+    public boolean isWC() {
+        return _tournamentInfo._params.wc;
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/BaseTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/BaseTournament.java
@@ -558,4 +558,9 @@ public abstract class BaseTournament implements Tournament {
             writeLock.unlock();
         }
     }
+
+    @Override
+    public boolean isWC() {
+        return _tournamentInfo._params.wc;
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/ConstructedTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/ConstructedTournament.java
@@ -136,4 +136,12 @@ public class ConstructedTournament extends BaseTournament implements Tournament 
                 getTournamentStage() == Tournament.Stage.PAUSED || getTournamentStage() == Tournament.Stage.AWAITING_KICKOFF)
                 && (maximumPlayers > activePlayers.size() || maximumPlayers < 0);
     }
+
+    @Override
+    public String getTableDescription() {
+        if (isWC()) {
+            return DateUtils.Now().getYear() + " World Championship";
+        }
+        return null;
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/ScheduledTournamentQueue.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/ScheduledTournamentQueue.java
@@ -58,7 +58,7 @@ public class ScheduledTournamentQueue extends AbstractTournamentQueue implements
     @Override
     public boolean isJoinable() {
         var window = _signupTimeBeforeStart;
-        if (_tournamentInfo.Parameters().tournamentId.toLowerCase().contains("wc")) {
+        if (isWC()) {
             window = _wcSignupTimeBeforeStart;
         }
         return DateUtils.Now().isAfter(_startTime.minus(window)) && (maximumPlayers < 0 || _players.size() < maximumPlayers);

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/Tournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/Tournament.java
@@ -209,4 +209,6 @@ public interface Tournament {
     boolean join(String playerName, LotroDeck lotroDeck);
     long getSecondsRemaining() throws IllegalStateException;
     String getTableDescription();
+
+    boolean isWC();
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentParams.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentParams.java
@@ -1,9 +1,6 @@
 package com.gempukku.lotro.tournament;
 
-import com.gempukku.lotro.game.LotroFormat;
-
 import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
 
 public class TournamentParams {
     public String tournamentId;
@@ -20,6 +17,8 @@ public class TournamentParams {
     public int minimumPlayers = 2;
     public int maximumPlayers = -1; // Negative value = no maximum set
     public Tournament.PrizeType prizes = Tournament.PrizeType.NONE;
+
+    public boolean wc = false;
 
     public Tournament.Stage getInitialStage() {
         if(manualKickoff)

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentQueue.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentQueue.java
@@ -50,4 +50,6 @@ public interface TournamentQueue {
     boolean confirmReadyCheck(String player);
 
     boolean hasConfirmedReadyCheck(String player);
+
+    boolean isWC();
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
@@ -253,7 +253,7 @@ public class TournamentService {
                     formatLibrary.getFormat(queue.getFormatCode()).getName(), queue.getInfo().Parameters().type.toString(), queue.getTournamentQueueName(),
                     queue.getPrizesDescription(), queue.getPairingDescription(), queue.getStartCondition(),
                     queue.getPlayerCount(), queue.getPlayerList(), queue.isPlayerSignedUp(player.getName()), queue.isJoinable(), queue.isStartable(player.getName()),
-                    queue.getSecondsRemainingForReadyCheck(), queue.hasConfirmedReadyCheck(player.getName()));
+                    queue.getSecondsRemainingForReadyCheck(), queue.hasConfirmedReadyCheck(player.getName()), queue.isWC());
         }
 
         for (var entry : _activeTournaments.entrySet()) {
@@ -269,7 +269,7 @@ public class TournamentService {
                     formatLibrary.getFormat(tournament.getFormatCode()).getName(), tournament.getTournamentName(), tournament.getInfo().Parameters().type.toString(), tournament.getPlayOffSystem(),
                     tournament.getTournamentStage().getHumanReadable(),
                     tournament.getCurrentRound(), tournament.getPlayersInCompetitionCount(), tournament.getPlayerList(), tournament.isPlayerInCompetition(player.getName()), tournament.isPlayerAbandoned(player.getName()),
-                    tournament.isJoinable(), secsRemaining);
+                    tournament.isJoinable(), secsRemaining, tournament.isWC());
         }
 
     }


### PR DESCRIPTION
So i have done some refactoring regarding the WC.

There are some assumptions:
1) being a WC tournament is mainly just a visual thing (+ timer and table names) -> a lot of things regarding the WC is being done manually? since i found no way to generate that upper/lower bracket with different formats and so on
2) WC event are always constructed (would need some changes to properly display sealed or draft wc events)

Work that has been done:
- scheduled wc queues are always in the waiting tables area, even if no players have registered yet, to promote visibility
- removed that hack with WC tournament names and done that on server
- fixed bug with admin scheduled queues that didnt start (not enough players joined) popping in hall every 60 secs for 1 sec
- wc is no longer identified by 'wc' in its id, it is now a proper part of TournamentParameters
- wc queues no longer get stuck in waiting tables
- extracted common code from if(isWC)/else branches in hallUI.js