### PR TITLE
UI Anything Goes js annoyances

### DIFF
--- a/gemp-lotr/gemp-lotr-async/src/main/web/deckBuild.html
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/deckBuild.html
@@ -96,7 +96,7 @@
 				<span class="ui-icon ui-icon-suitcase"></span>
 			</button>
 			
-			<button id="convertErrataBut" title="Convert to PC Errata" class="menu-button">
+			<button id="convertErrataBut" title="Convert to PC Errata" class="menu-button" disabled>
 				<span class="ui-icon ui-icon-transferthick-e-w"></span>
 			</button>
 

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/deckBuildingUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/deckBuildingUi.js
@@ -61,6 +61,7 @@ var GempLotrDeckBuildingUI = Class.extend({
 	cardInfoDialog: null,
 	
 	formats: null,
+	formatsInitialized:false,
 
 	init:function () {
 		var that = this;
@@ -110,14 +111,14 @@ var GempLotrDeckBuildingUI = Class.extend({
 						that.setMapVisibility(false);
 					}
 					
-					//PC format or Anything Goes
-					if(formatCode.includes("pc") || formatCode == "rev_tow_sta") {
+					//PC format or Anything Goes (if chosen, not when being default when page loads)
+					if((formatCode.includes("pc") || formatCode == "rev_tow_sta") && that.formatsInitialized) {
 						$("#convertErrataBut").button("option", "disabled", false);
 					}
 					else {
 						$("#convertErrataBut").button("option", "disabled", true);
 					}
-					
+
 					that.cardFilter.updateFormat(formatCode, that.formats[formatCode].blockFilters);
 				});
 		
@@ -1032,6 +1033,12 @@ var GempLotrDeckBuildingUI = Class.extend({
 			this.deckValidationDirty = true;
 			this.deckContentsDirty = true;
 			$("#editingDeck").html("<font color='orange'>*" + name + " - modified</font>");
+
+            //Enable the errata button if user starts adding cards to empty 'Anything Goes' deck after the page was initialized
+			let formatCode = this.formatSelect.val();
+            if(formatCode == "rev_tow_sta") {
+                $("#convertErrataBut").button("option", "disabled", false);
+            }
 		}
 		else
 		{
@@ -1121,6 +1128,8 @@ var GempLotrDeckBuildingUI = Class.extend({
 					that.formatSelect.change();
 					const sleep = ms => new Promise(r => setTimeout(r, ms));
 					that.showNormalFilter();
+
+					that.formatsInitialized = true;
 
 					that.getCollectionTypes();
 				}, 

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -1155,6 +1155,9 @@ var GempLotrHallUI = Class.extend({
 					var type = formats[i].getAttribute("type");
 					
 					var item = "<option value='" + type + "'>" + format + "</option>"
+
+                    var selected = (format === "Fellowship Block") ? " selected" : "";
+                    var item = "<option value='" + type + "'" + selected + ">" + format + "</option>";
 					
 					this.supportedFormatsSelect.append(item);
 				}

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -1153,8 +1153,6 @@ var GempLotrHallUI = Class.extend({
 				for (var i = 0; i < formats.length; i++) {
 					var format = formats[i].childNodes[0].nodeValue;
 					var type = formats[i].getAttribute("type");
-					
-					var item = "<option value='" + type + "'>" + format + "</option>"
 
                     var selected = (format === "Fellowship Block") ? " selected" : "";
                     var item = "<option value='" + type + "'" + selected + ">" + format + "</option>";


### PR DESCRIPTION
Only js and html files changed, no server restart needed

1) Default hall format when page loads is fellowship block instead of anything goes - only the format selector drop down is modified, deck selector still shows anything goes decks first.
![image](https://github.com/user-attachments/assets/e1376f6c-0083-4d84-a76b-6ea33341e317)

2) Convert errata button in deck builder is disabled when the page loads - cannot tell how many times i missclicked my decks / library since their 'position' changes (sometimes they are the right-most button, sometimes not, based on if i had just loaded the page or if i have looked at one of the decks already).
If format is switched to Anything Goes (not when the page loads), the convert button is enabled. It is also enabled after page loads if user starts adding cards to empty anything goes deck.
![image](https://github.com/user-attachments/assets/4124c1d9-8965-428e-adee-c14ca7e34008)
