### PR TITLE
Update We Must Go Wearily to exert twice

### DIFF
--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set03/set03-Gondor.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/cards/official/set03/set03-Gondor.hjson
@@ -532,6 +532,7 @@
 			}
 			cost: {
 				type: exert
+				count: 2
 				select: choose(culture(gondor),companion)
 			}
 			effect: {


### PR DESCRIPTION
This PR increase the exertion-cost count of We Must Go Wearily to 2 to match it's text. 

Related to #704 