### PR TITLE
Tournament Queue Configurator + Hall Changes

### DIFF
--- a/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/AdminRequestHandler.java
+++ b/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/AdminRequestHandler.java
@@ -130,8 +130,28 @@ public class AdminRequestHandler extends LotroServerRequestHandler implements Ur
             unBanUser(request, responseWriter);
         } else if (uri.equals("/findMultipleAccounts") && request.method() == HttpMethod.POST) {
             findMultipleAccounts(request, responseWriter);
+        } else if (uri.equals("/toggleSealedHallStatus") && request.method() == HttpMethod.POST) {
+            toggleSealedHallStatus(request, responseWriter);
         } else {
             throw new HttpProcessingException(404);
+        }
+    }
+
+    private void toggleSealedHallStatus(HttpRequest request, ResponseWriter responseWriter) throws Exception {
+        validateEventAdmin(request);
+        var postDecoder = new HttpPostRequestDecoder(request);
+
+        String sealedFormatCodeStr = getFormParameterSafely(postDecoder, "sealedFormatCode");
+
+
+        Throw400IfStringNull("sealedFormatCode", sealedFormatCodeStr);
+        var sealedFormat = _formatLibrary.GetSealedTemplate(sealedFormatCodeStr);
+        Throw400IfValidationFails("sealedFormatCode", sealedFormatCodeStr,sealedFormat != null);
+
+        if (_formatLibrary.toggleSealedInHall(sealedFormatCodeStr)) {
+            responseWriter.writeHtmlResponse("Added format");
+        } else {
+            responseWriter.writeHtmlResponse("Removed format");
         }
     }
 

--- a/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/AdminRequestHandler.java
+++ b/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/AdminRequestHandler.java
@@ -981,6 +981,7 @@ public class AdminRequestHandler extends LotroServerRequestHandler implements Ur
         Throw400IfValidationFails("name", name, name.length() <= 45, "Tournament name must be 45 characters or less.");
         boolean wc = ParseBoolean("wc", wcStr, false);
         Throw400IfStringNull("tournamentId", tournamentId);
+        Throw400IfValidationFails("tournamentId", tournamentId, !tournamentId.contains(" "), "Tournament id must not contain spaces.");
         Throw400IfStringNull("format", formatStr);
         Throw400IfStringNull("start", startStr);
 

--- a/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
+++ b/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
@@ -33,6 +33,7 @@ import java.lang.reflect.Type;
 import java.text.DecimalFormat;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -109,6 +110,7 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
         data.sealed = _formatLibrary.getAllHallSealedTemplates().values().stream()
                 .map(sealed -> new JSONDefs.ItemStub(sealed.GetID(), sealed.GetName().substring(3)))
                 .collect(Collectors.toList());
+        data.sealed.sort(Comparator.comparing(o -> _formatLibrary.GetSealedTemplate(o.code).GetName())); // Sort by sealed format number
         data.soloDrafts = orderedSoloDrafts.stream()
                 .filter(code -> _soloDraftDefinitions.getAllSoloDrafts().values().stream().anyMatch(soloDraft -> code.equals(soloDraft.getCode()))).map(code -> new JSONDefs.ItemStub(code, availableSoloDraftFormats.get(code)))
                 .collect(Collectors.toList());

--- a/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
+++ b/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
@@ -229,7 +229,7 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
             var tableDraftDefinition = _tableDraftLibrary.getTableDraftDefinition(tableDraftFormatCodeStr);
             Throw400IfValidationFails("tableDraftFormatCode", tableDraftFormatCodeStr,tableDraftDefinition != null);
             //Check if all players can get to one table
-            Throw400IfValidationFails("maxPlayers", maxPlayersStr, tableDraftDefinition.getMaxPlayers() < maxPlayers);
+            Throw400IfValidationFails("maxPlayers", maxPlayersStr, tableDraftDefinition.getMaxPlayers() > maxPlayers);
             tableDraftParams.tableDraftFormatCode = tableDraftFormatCodeStr;
             tableDraftParams.format = tableDraftDefinition.getFormat();
             tableDraftParams.draftTimerType = DraftTimer.getTypeFromString(tableDraftTimer);

--- a/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
+++ b/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
@@ -97,15 +97,6 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
     private void getTournamentFormats(HttpRequest request, ResponseWriter responseWriter) {
         JSONDefs.PlayerMadeTournamentAvailableFormats data = new JSONDefs.PlayerMadeTournamentAvailableFormats();
 
-        Map<String, String> availableSealedFormats = new HashMap<>();
-        availableSealedFormats.put("single_fotr_block_sealed", "Fellowship Block Sealed");
-        availableSealedFormats.put("single_ttt_block_sealed", "Towers Block Sealed");
-        availableSealedFormats.put("single_ts_sealed", "Towers Standard Sealed");
-        availableSealedFormats.put("single_rotk_block_sealed", "King Block Sealed");
-        availableSealedFormats.put("single_movie_sealed", "Movie Sealed");
-        availableSealedFormats.put("single_wotr_block_sealed", "War of the Ring Block Sealed");
-        availableSealedFormats.put("single_th_block_sealed", "Hunters Block Sealed");
-
         Map<String, String> availableSoloDraftFormats = new HashMap<>();
         availableSoloDraftFormats.put("fotr_draft", "Fellowship Block");
         availableSoloDraftFormats.put("ttt_draft", "Towers Block");
@@ -115,9 +106,8 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
         data.constructed = _formatLibrary.getHallFormats().values().stream()
                 .map(constructedFormat -> new JSONDefs.ItemStub(constructedFormat.getCode(), constructedFormat.getName()))
                 .collect(Collectors.toList());
-        data.sealed = _formatLibrary.GetAllSealedTemplates().values().stream()
-                .filter(sealedEventDefinition -> availableSealedFormats.containsKey(sealedEventDefinition.GetID()))
-                .map(sealed -> new JSONDefs.ItemStub(sealed.GetID(), availableSealedFormats.get(sealed.GetID())))
+        data.sealed = _formatLibrary.getAllHallSealedTemplates().values().stream()
+                .map(sealed -> new JSONDefs.ItemStub(sealed.GetID(), sealed.GetName().substring(3)))
                 .collect(Collectors.toList());
         data.soloDrafts = orderedSoloDrafts.stream()
                 .filter(code -> _soloDraftDefinitions.getAllSoloDrafts().values().stream().anyMatch(soloDraft -> code.equals(soloDraft.getCode()))).map(code -> new JSONDefs.ItemStub(code, availableSoloDraftFormats.get(code)))

--- a/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
+++ b/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
@@ -35,7 +35,6 @@ import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class TournamentRequestHandler extends LotroServerRequestHandler implements UriRequestHandler {
@@ -139,6 +138,9 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
         String competitiveStr = getFormParameterSafely(postDecoder, "competitive");
         boolean competitive = Throw400IfNullOrNonBoolean("competitive", competitiveStr);
 
+        String startableStr = getFormParameterSafely(postDecoder, "startable");
+        boolean startable = Throw400IfNullOrNonBoolean("startable", startableStr);
+
         String sealedFormatCodeStr = getFormParameterSafely(postDecoder, "sealedFormatCode");
 
         String soloDraftFormatCodeStr = getFormParameterSafely(postDecoder, "soloDraftFormatCode");
@@ -164,7 +166,7 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
         String competitivePrefix = "Competitive ";
         String prefix = competitive ? competitivePrefix : casualPrefix;
 
-        //TODO ready check, ready check time, startable early
+        //TODO ready check, ready check time
 
         if(type == Tournament.TournamentType.SEALED) {
             var sealedParams = new SealedTournamentParams();
@@ -264,7 +266,7 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
             return;
         }
 
-        if (_hallServer.addPlayerMadeLimitedQueue(info, resourceOwner, false, -1)) {
+        if (_hallServer.addPlayerMadeLimitedQueue(info, resourceOwner, startable, -1)) {
             responseWriter.sendJsonOK();
         } else {
             Throw400IfValidationFails("Error", "Error", false, "Error while creating queue or joining");

--- a/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
+++ b/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
@@ -249,7 +249,7 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
             var tableDraftDefinition = _tableDraftLibrary.getTableDraftDefinition(tableDraftFormatCodeStr);
             Throw400IfValidationFails("tableDraftFormatCode", tableDraftFormatCodeStr,tableDraftDefinition != null);
             //Check if all players can get to one table
-            Throw400IfValidationFails("maxPlayers", maxPlayersStr, tableDraftDefinition.getMaxPlayers() > maxPlayers);
+            Throw400IfValidationFails("maxPlayers", maxPlayersStr, tableDraftDefinition.getMaxPlayers() >= maxPlayers);
             tableDraftParams.tableDraftFormatCode = tableDraftFormatCodeStr;
             tableDraftParams.format = tableDraftDefinition.getFormat();
             tableDraftParams.draftTimerType = DraftTimer.getTypeFromString(tableDraftTimer);

--- a/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
+++ b/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
@@ -116,7 +116,7 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
                 .filter(code -> _soloDraftDefinitions.getAllSoloDrafts().values().stream().anyMatch(soloDraft -> code.equals(soloDraft.getCode()))).map(code -> new JSONDefs.ItemStub(code, availableSoloDraftFormats.get(code)))
                 .collect(Collectors.toList());
         data.tableDrafts = _tableDraftLibrary.getAllTableDrafts().stream()
-                .map(tableDraftDefinition -> new JSONDefs.ItemStub(tableDraftDefinition.getCode(), tableDraftDefinition.getName()))
+                .map(tableDraftDefinition -> new JSONDefs.LiveDraftInfo(tableDraftDefinition.getCode(), tableDraftDefinition.getName(), tableDraftDefinition.getMaxPlayers(), tableDraftDefinition.getRecommendedTimer().name()))
                 .collect(Collectors.toList());
         data.draftTimerTypes = DraftTimer.getAllTypes();
 
@@ -228,6 +228,8 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
             Throw400IfStringNull("tableDraftFormatCode", tableDraftFormatCodeStr);
             var tableDraftDefinition = _tableDraftLibrary.getTableDraftDefinition(tableDraftFormatCodeStr);
             Throw400IfValidationFails("tableDraftFormatCode", tableDraftFormatCodeStr,tableDraftDefinition != null);
+            //Check if all players can get to one table
+            Throw400IfValidationFails("maxPlayers", maxPlayersStr, tableDraftDefinition.getMaxPlayers() < maxPlayers);
             tableDraftParams.tableDraftFormatCode = tableDraftFormatCodeStr;
             tableDraftParams.format = tableDraftDefinition.getFormat();
             tableDraftParams.draftTimerType = DraftTimer.getTypeFromString(tableDraftTimer);
@@ -244,7 +246,7 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
         params.cost = 0; // Gold is not being used, they can be free to enter
         params.playoff = Tournament.PairingType.parse(playoff);
         params.tiebreaker = "owr";
-        params.prizes = Tournament.PrizeType.LIMITED; // At 4+ players, get one Event Award for each win or buy
+        params.prizes = Tournament.PrizeType.LIMITED; // At 4+ players, get one Event Award for each win or bye
         params.maximumPlayers = maxPlayers;
         params.manualKickoff = false;
 

--- a/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
+++ b/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
@@ -141,6 +141,9 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
         String startableStr = getFormParameterSafely(postDecoder, "startable");
         boolean startable = Throw400IfNullOrNonBoolean("startable", startableStr);
 
+        String readyCheckStr = getFormParameterSafely(postDecoder, "readyCheck");
+        int readyCheck = Throw400IfNullOrNonInteger("readyCheck", readyCheckStr);
+
         String sealedFormatCodeStr = getFormParameterSafely(postDecoder, "sealedFormatCode");
 
         String soloDraftFormatCodeStr = getFormParameterSafely(postDecoder, "soloDraftFormatCode");
@@ -161,12 +164,9 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
 
         var params = new TournamentParams();
 
-
         String casualPrefix = "Casual ";
         String competitivePrefix = "Competitive ";
         String prefix = competitive ? competitivePrefix : casualPrefix;
-
-        //TODO ready check, ready check time
 
         if(type == Tournament.TournamentType.SEALED) {
             var sealedParams = new SealedTournamentParams();
@@ -266,7 +266,7 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
             return;
         }
 
-        if (_hallServer.addPlayerMadeLimitedQueue(info, resourceOwner, startable, -1)) {
+        if (_hallServer.addPlayerMadeLimitedQueue(info, resourceOwner, startable, readyCheck)) {
             responseWriter.sendJsonOK();
         } else {
             Throw400IfValidationFails("Error", "Error", false, "Error while creating queue or joining");

--- a/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
+++ b/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
@@ -3,15 +3,23 @@ package com.gempukku.lotro.async.handler;
 import com.gempukku.lotro.async.HttpProcessingException;
 import com.gempukku.lotro.async.ResponseWriter;
 import com.gempukku.lotro.collection.DeckRenderer;
+import com.gempukku.lotro.common.DateUtils;
+import com.gempukku.lotro.common.JSONDefs;
 import com.gempukku.lotro.competitive.PlayerStanding;
+import com.gempukku.lotro.draft2.SoloDraftDefinitions;
+import com.gempukku.lotro.draft3.TableDraftDefinitions;
+import com.gempukku.lotro.draft3.timer.DraftTimer;
 import com.gempukku.lotro.game.LotroCardBlueprintLibrary;
+import com.gempukku.lotro.game.Player;
 import com.gempukku.lotro.game.SortAndFilterCards;
 import com.gempukku.lotro.game.formats.LotroFormatLibrary;
 import com.gempukku.lotro.logic.vo.LotroDeck;
-import com.gempukku.lotro.tournament.Tournament;
-import com.gempukku.lotro.tournament.TournamentService;
+import com.gempukku.lotro.packs.ProductLibrary;
+import com.gempukku.lotro.tournament.*;
+import com.gempukku.util.JsonUtils;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
@@ -23,8 +31,11 @@ import java.lang.reflect.Type;
 import java.text.DecimalFormat;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class TournamentRequestHandler extends LotroServerRequestHandler implements UriRequestHandler {
 
@@ -36,6 +47,10 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
     private final SortAndFilterCards _sortAndFilterCards;
     private final DeckRenderer _deckRenderer;
 
+    private final SoloDraftDefinitions _soloDraftDefinitions;
+    private final TableDraftDefinitions _tableDraftLibrary;
+    private final ProductLibrary _productLibrary;
+
     private static final Logger _log = LogManager.getLogger(TournamentRequestHandler.class);
 
     public TournamentRequestHandler(Map<Type, Object> context) {
@@ -45,6 +60,10 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
         _formatLibrary = extractObject(context, LotroFormatLibrary.class);
         _library = extractObject(context, LotroCardBlueprintLibrary.class);
         _sortAndFilterCards = new SortAndFilterCards();
+
+        _soloDraftDefinitions = extractObject(context, SoloDraftDefinitions.class);
+        _tableDraftLibrary = extractObject(context, TableDraftDefinitions.class);
+        _productLibrary = extractObject(context, ProductLibrary.class);
 
         _deckRenderer = new DeckRenderer(_library, _formatLibrary, _sortAndFilterCards);
     }
@@ -59,10 +78,183 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
             getTournamentDeck(request, uri.substring(1, uri.indexOf("/deck/")), uri.substring(uri.indexOf("/deck/") + 6, uri.lastIndexOf("/html")), responseWriter);
         } else if (uri.startsWith("/") && uri.endsWith("/html") && uri.contains("/report/") && request.method() == HttpMethod.GET) {
             getTournamentReport(request, uri.substring(1, uri.indexOf("/report/")), responseWriter);
+        } else if (uri.equals("/create") && request.method() == HttpMethod.POST) {
+            processPlayerMadeTournament(request, responseWriter);
+        } else if (uri.equals("/limitedFormats") && request.method() == HttpMethod.GET) {
+            getLimitedFormats(request, responseWriter);
         } else if (uri.startsWith("/") && request.method() == HttpMethod.GET) {
             getTournamentInfo(request, uri.substring(1), responseWriter);
         } else {
             throw new HttpProcessingException(404);
+        }
+    }
+
+    private void getLimitedFormats(HttpRequest request, ResponseWriter responseWriter) {
+        JSONDefs.PlayerMadeTournamentAvailableFormats data = new JSONDefs.PlayerMadeTournamentAvailableFormats();
+        Map<String, String> availableSealedFormats = new HashMap<>();
+        availableSealedFormats.put("single_fotr_block_sealed", "Fellowship Block Sealed");
+        availableSealedFormats.put("single_ttt_block_sealed", "Towers Block Sealed");
+        availableSealedFormats.put("single_ts_sealed", "Towers Standard Sealed");
+        availableSealedFormats.put("single_rotk_block_sealed", "King Block Sealed");
+        availableSealedFormats.put("single_movie_sealed", "Movie Sealed");
+        availableSealedFormats.put("single_wotr_block_sealed", "War of the Ring Block Sealed");
+        availableSealedFormats.put("single_th_block_sealed", "Hunters Block Sealed");
+        Map<String, String> availableSoloDraftFormats = new HashMap<>();
+        availableSoloDraftFormats.put("fotr_draft", "Fellowship Block");
+        availableSoloDraftFormats.put("ttt_draft", "Towers Block");
+        availableSoloDraftFormats.put("hobbit_random_draft", "Hobbit");
+        List<String> orderedSoloDrafts = List.of("fotr_draft", "ttt_draft", "hobbit_random_draft");
+        data.sealed = _formatLibrary.GetAllSealedTemplates().values().stream()
+                .filter(sealedEventDefinition -> availableSealedFormats.containsKey(sealedEventDefinition.GetID()))
+                .map(sealed -> new JSONDefs.ItemStub(sealed.GetID(), availableSealedFormats.get(sealed.GetID())))
+                .collect(Collectors.toList());
+        data.soloDrafts = orderedSoloDrafts.stream()
+                .filter(code -> _soloDraftDefinitions.getAllSoloDrafts().values().stream().anyMatch(soloDraft -> code.equals(soloDraft.getCode()))).map(code -> new JSONDefs.ItemStub(code, availableSoloDraftFormats.get(code)))
+                .collect(Collectors.toList());
+        data.tableDrafts = _tableDraftLibrary.getAllTableDrafts().stream()
+                .map(tableDraftDefinition -> new JSONDefs.ItemStub(tableDraftDefinition.getCode(), tableDraftDefinition.getName()))
+                .collect(Collectors.toList());
+        data.draftTimerTypes = DraftTimer.getAllTypes();
+
+        responseWriter.writeJsonResponse(JsonUtils.Serialize(data));
+    }
+
+    private void processPlayerMadeTournament(HttpRequest request, ResponseWriter responseWriter) throws Exception {
+        var postDecoder = new HttpPostRequestDecoder(request);
+
+        String participantId = getFormParameterSafely(postDecoder, "participantId");
+        Player resourceOwner = getResourceOwnerSafely(request, participantId);
+
+        String typeStr = getFormParameterSafely(postDecoder, "type");
+        String deckbuildingDurationStr = getFormParameterSafely(postDecoder, "deckbuildingDuration");
+        String playoff = getFormParameterSafely(postDecoder, "playoff");
+        String maxPlayersStr = getFormParameterSafely(postDecoder, "maxPlayers");
+
+        String sealedFormatCodeStr = getFormParameterSafely(postDecoder, "sealedFormatCode");
+
+        String soloDraftFormatCodeStr = getFormParameterSafely(postDecoder, "soloDraftFormatCode");
+
+        String soloTableDraftFormatCodeStr = getFormParameterSafely(postDecoder, "soloTableDraftFormatCode");
+
+        String tableDraftFormatCodeStr = getFormParameterSafely(postDecoder, "tableDraftFormatCode");
+        String tableDraftTimer = getFormParameterSafely(postDecoder, "tableDraftTimer");
+
+
+        Throw400IfStringNull("type", typeStr);
+        var type = Tournament.TournamentType.parse(typeStr);
+        Throw400IfValidationFails("type", typeStr, type != null);
+
+        Throw400IfValidationFails("playoff", playoff,Tournament.getPairingMechanism(playoff) != null);
+
+        int maxPlayers = Throw400IfNullOrNonInteger("maxPlayers", maxPlayersStr);
+
+        var params = new TournamentParams();
+
+
+        String casual = "Casual ";
+
+        if(type == Tournament.TournamentType.SEALED) {
+            var sealedParams = new SealedTournamentParams();
+            sealedParams.type = Tournament.TournamentType.SEALED;
+
+            sealedParams.deckbuildingDuration = Throw400IfNullOrNonInteger("deckbuildingDuration", deckbuildingDurationStr);
+            sealedParams.turnInDuration = 0;
+
+            Throw400IfStringNull("sealedFormatCode", sealedFormatCodeStr);
+            var sealedFormat = _formatLibrary.GetSealedTemplate(sealedFormatCodeStr);
+            Throw400IfValidationFails("sealedFormatCode", sealedFormatCodeStr,sealedFormat != null);
+            sealedParams.sealedFormatCode = sealedFormatCodeStr;
+            sealedParams.format = sealedFormat.GetFormat().getCode();
+            sealedParams.name = casual + sealedFormat.GetName();
+            params = sealedParams;
+        }
+        else if (type == Tournament.TournamentType.SOLODRAFT) {
+            var soloDraftParams = new SoloDraftTournamentParams();
+            soloDraftParams.type = Tournament.TournamentType.SOLODRAFT;
+
+            soloDraftParams.deckbuildingDuration = Throw400IfNullOrNonInteger("soloDraftDeckbuildingDuration", deckbuildingDurationStr);
+            soloDraftParams.turnInDuration = 0;
+
+            Throw400IfStringNull("soloDraftFormatCode", soloDraftFormatCodeStr);
+            var soloDraftFormat = _soloDraftDefinitions.getSoloDraft(soloDraftFormatCodeStr);
+            Throw400IfValidationFails("soloDraftFormatCode", soloDraftFormatCodeStr,soloDraftFormat != null);
+            soloDraftParams.soloDraftFormatCode = soloDraftFormatCodeStr;
+            soloDraftParams.format = soloDraftFormat.getFormat();
+            switch (soloDraftFormatCodeStr) {
+                case "fotr_draft" -> soloDraftParams.name = casual + "FotR Solo Draft";
+                case "ttt_draft" -> soloDraftParams.name = casual + "TTT Solo Draft";
+                case "hobbit_random_draft" -> soloDraftParams.name = casual + "Hobbit Solo Draft";
+                default -> soloDraftParams.name = casual + soloDraftFormatCodeStr;
+            }
+            params = soloDraftParams;
+        }
+        else if (type == Tournament.TournamentType.TABLE_SOLODRAFT) {
+            var soloTableDraftParams = new SoloTableDraftTournamentParams();
+            soloTableDraftParams.type = Tournament.TournamentType.TABLE_SOLODRAFT;
+
+            soloTableDraftParams.deckbuildingDuration = Throw400IfNullOrNonInteger("soloTableDraftDeckbuildingDuration", deckbuildingDurationStr);
+            soloTableDraftParams.turnInDuration = 0;
+
+            Throw400IfStringNull("soloTableDraftFormatCode", soloTableDraftFormatCodeStr);
+            var tableDraftDefinition = _tableDraftLibrary.getTableDraftDefinition(soloTableDraftFormatCodeStr);
+            Throw400IfValidationFails("soloTableDraftFormatCode", soloTableDraftFormatCodeStr,tableDraftDefinition != null);
+            soloTableDraftParams.soloTableDraftFormatCode = soloTableDraftFormatCodeStr;
+            soloTableDraftParams.format = tableDraftDefinition.getFormat();
+            soloTableDraftParams.name = casual + tableDraftDefinition.getName();
+            params = soloTableDraftParams;
+        }
+        else if (type == Tournament.TournamentType.TABLE_DRAFT) {
+            var tableDraftParams = new TableDraftTournamentParams();
+            tableDraftParams.type = Tournament.TournamentType.TABLE_DRAFT;
+
+            tableDraftParams.deckbuildingDuration = Throw400IfNullOrNonInteger("tableDraftDeckbuildingDuration", deckbuildingDurationStr);
+            tableDraftParams.turnInDuration = 0;
+
+            Throw400IfStringNull("tableDraftFormatCode", tableDraftFormatCodeStr);
+            var tableDraftDefinition = _tableDraftLibrary.getTableDraftDefinition(tableDraftFormatCodeStr);
+            Throw400IfValidationFails("tableDraftFormatCode", tableDraftFormatCodeStr,tableDraftDefinition != null);
+            tableDraftParams.tableDraftFormatCode = tableDraftFormatCodeStr;
+            tableDraftParams.format = tableDraftDefinition.getFormat();
+            tableDraftParams.draftTimerType = DraftTimer.getTypeFromString(tableDraftTimer);
+            tableDraftParams.name = casual + tableDraftDefinition.getName();
+            params = tableDraftParams;
+        }
+        else {
+            Throw400IfValidationFails("type", typeStr, false, "Only limited games");
+            return;
+        }
+
+        params.requiresDeck = false;
+        params.tournamentId =  params.format + System.currentTimeMillis();
+        params.cost = 0; // Gold is not being used, they can be free to enter
+        params.playoff = Tournament.PairingType.parse(playoff);
+        params.tiebreaker = "owr";
+        params.prizes = Tournament.PrizeType.LIMITED; // At 4+ players, get one Event Award for each win or buy
+        params.maximumPlayers = maxPlayers;
+        params.manualKickoff = false;
+
+        TournamentInfo info;
+        if(type == Tournament.TournamentType.SEALED) {
+            info = new SealedTournamentInfo(_tournamentService, _productLibrary, _formatLibrary, DateUtils.Today(), (SealedTournamentParams)params);
+        }
+        else if (type == Tournament.TournamentType.SOLODRAFT) {
+            info = new SoloDraftTournamentInfo(_tournamentService, _productLibrary, _formatLibrary, DateUtils.Today(), ((SoloDraftTournamentParams) params), _soloDraftDefinitions);
+        }
+        else if (type == Tournament.TournamentType.TABLE_SOLODRAFT) {
+            info = new SoloTableDraftTournamentInfo(_tournamentService, _productLibrary, _formatLibrary, DateUtils.Today(), ((SoloTableDraftTournamentParams) params), _tableDraftLibrary);
+        }
+        else if (type == Tournament.TournamentType.TABLE_DRAFT) {
+            info = new TableDraftTournamentInfo(_tournamentService, _productLibrary, _formatLibrary, DateUtils.Today(), ((TableDraftTournamentParams) params), _tableDraftLibrary);
+        }
+        else {
+            Throw400IfValidationFails("type", typeStr, false, "Only limited games");
+            return;
+        }
+
+        if (_tournamentService.addPlayerMadeLimitedQueue(info, resourceOwner, false, -1)) {
+            responseWriter.sendJsonOK();
+        } else {
+            Throw400IfValidationFails("Error", "Error", false, "Error while creating queue or joining");
         }
     }
 

--- a/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/hall.css
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/hall.css
@@ -294,10 +294,6 @@ table.tables tr.privateForPlayer {
 	background-color: #840000;
 }
 
-.wc-events {
-	background-color: #666619;
-}
-
 .tableFormatName {
 	text-align: center;
 	font-weight: bold;

--- a/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/hall.css
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/hall.css
@@ -853,6 +853,7 @@ table.standings {
 #limitedGameForm {
   display: grid;
   margin-left: 20px;
+  padding-top: 8px;
   padding-bottom: 20px;
   gap: 8px;
   max-width: 400px;
@@ -875,5 +876,12 @@ form#limitedGameForm input {
 
 #advancedFields {
   display: grid;
+  gap: 8px;
+}
+
+.formRow {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
   gap: 8px;
 }

--- a/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/hall.css
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/hall.css
@@ -885,3 +885,7 @@ form#queueSpawnerForm input {
   align-items: center;
   gap: 8px;
 }
+
+.italic {
+   font-style: italic;
+ }

--- a/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/hall.css
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/hall.css
@@ -889,3 +889,7 @@ form#queueSpawnerForm input {
 .italic {
    font-style: italic;
  }
+
+.bold {
+   font-weight: bold;
+ }

--- a/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/hall.css
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/hall.css
@@ -849,3 +849,31 @@ table.standings {
 #announcement-dialog ul {
 	margin-bottom: 5px;
 }
+
+#limitedGameForm {
+  display: grid;
+  margin-left: 20px;
+  padding-bottom: 20px;
+  gap: 8px;
+  max-width: 400px;
+}
+
+form#limitedGameForm select {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+form#limitedGameForm input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+#dynamicFields {
+  display: grid;
+  gap: 8px;
+}
+
+#advancedFields {
+  display: grid;
+  gap: 8px;
+}

--- a/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/hall.css
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/hall.css
@@ -288,6 +288,9 @@ table.tables tr.privateForPlayer {
 	padding: 4px;
 	margin: 2px;
 	border-radius: 3px;
+	display: flex;
+	align-items: center;
+	gap: 6px;
 }
 
 .wc-queues {
@@ -889,3 +892,21 @@ form#queueSpawnerForm input {
 .bold {
    font-weight: bold;
  }
+
+.disclosureTriangle {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  margin-left: 4px;
+  margin-right: 4px;
+  vertical-align: middle;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-left: 8px solid #fff;
+  transition: transform 0.2s ease;
+}
+
+/* Rotate down when expanded */
+.eventHeader.expanded .disclosureTriangle {
+  transform: rotate(90deg);
+}

--- a/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/hall.css
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/css/gemp-001/hall.css
@@ -850,7 +850,7 @@ table.standings {
 	margin-bottom: 5px;
 }
 
-#limitedGameForm {
+#queueSpawnerForm {
   display: grid;
   margin-left: 20px;
   padding-top: 8px;
@@ -859,12 +859,12 @@ table.standings {
   max-width: 400px;
 }
 
-form#limitedGameForm select {
+form#queueSpawnerForm select {
   width: 100%;
   box-sizing: border-box;
 }
 
-form#limitedGameForm input {
+form#queueSpawnerForm input {
   width: 100%;
   box-sizing: border-box;
 }

--- a/gemp-lotr/gemp-lotr-async/src/main/web/hall.html
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/hall.html
@@ -226,14 +226,15 @@
 						</table>
 					</div>
 
-					<div id="limitedGamesHeader" class='eventHeader limitedGames'>Limited Games</div>
-					<div id="limitedGamesContent" class='visibilityToggle'>
-						<form id="limitedGameForm">
+					<div id="queueSpawnerHeader" class='eventHeader limitedGames'>Tournaments & Limited Games</div>
+					<div id="queueSpawnerContent" class='visibilityToggle'>
+						<form id="queueSpawnerForm">
 							<!-- Game Type Selection -->
 							<div class="formRow">
 								<label for="gameTypeSelect">Type of Game:</label>
 								<select id="gameTypeSelect" name="gameType">
 									<option value="" disabled selected>Select game type</option>
+									<option value="constructed">Constructed</option>
 									<option value="sealed">Sealed</option>
 									<option value="table_draft">Live Draft</option>
 									<option value="solodraft">Solo Draft</option>

--- a/gemp-lotr/gemp-lotr-async/src/main/web/hall.html
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/hall.html
@@ -185,11 +185,12 @@
 						<table class='tables wc-queues'>
 							<tr>
 								<th width='10%'>Format</th>
-								<th width='20%'>Event</th>
+								<th width='8%'>Collection</th>
+								<th width='30%'>Event Name</th>
 								<th width='16%'>Starts</th>
-								<th width='10%'>System</th>
-								<th width='6%'>Players</th>
-								<th width='10%'>Actions</th>
+								<th width='16%'>System</th>
+								<th width='8%'>Cost</th>
+								<th width='12%'>Prizes</th>
 							</tr>
 						</table>
 					</div>
@@ -199,34 +200,47 @@
 						<table class='tables wc-events'>
 							<tr>
 								<th width='10%'>Format</th>
-								<th width='20%'>Event</th>
+								<th width='8%'>Collection</th>
+								<th width='20%'>Event Name</th>
 								<th width='10%'>System</th>
 								<th width='16%'>Stage</th>
 								<th width='6%'>Round</th>
-								<th width='6%'>Players</th>
-								<th width='10%'>Actions</th>
-							</tr>
-						</table>
-					</div>
-					
-					<div id="tournamentQueuesHeader" class='eventHeader queues'>Tournament Queues<span class='count'>(0)</span></div>
-					<div id="tournamentQueuesContent" class='visibilityToggle'>
-						<table class='tables queues'>
-							<tr>
-								<th width='10%'>Format</th>
-								<th width='8%'>Collection</th>
-								<th width='20%'>Queue name</th>
-								<th width='16%'>Starts</th>
-								<th width='10%'>System</th>
-								<th width='6%'>Players</th>
-								<th width='8%'>Cost</th>
-								<th width='12%'>Prizes</th>
-								<th width='10%'>Actions</th>
+								<th width='8%'>Players</th>
 							</tr>
 						</table>
 					</div>
 
-					<div id="queueSpawnerHeader" class='eventHeader limitedGames'>Tournaments & Limited Games</div>
+					<div id="scheduledQueuesHeader" class='eventHeader scheduledQueues'>Scheduled Events<span class='count'>(0)</span></div>
+					<div id="scheduledQueuesContent" class='visibilityToggle'>
+						<table class='tables scheduledQueues'>
+							<tr>
+								<th width='10%'>Format</th>
+								<th width='8%'>Collection</th>
+								<th width='30%'>Event Name</th>
+								<th width='16%'>Starts</th>
+								<th width='16%'>System</th>
+								<th width='8%'>Cost</th>
+								<th width='12%'>Prizes</th>
+							</tr>
+						</table>
+					</div>
+					
+					<div id="recurringQueuesHeader" class='eventHeader recurringQueues'>Recurring Events<span class='count'>(0)</span></div>
+					<div id="recurringQueuesContent" class='visibilityToggle'>
+						<table class='tables recurringQueues'>
+							<tr>
+								<th width='10%'>Format</th>
+								<th width='8%'>Collection</th>
+								<th width='30%'>Event Name</th>
+								<th width='16%'>Next Start</th>
+								<th width='16%'>System</th>
+								<th width='8%'>Cost</th>
+								<th width='12%'>Prizes</th>
+							</tr>
+						</table>
+					</div>
+
+					<div id="queueSpawnerHeader" class='eventHeader limitedGames'>Create Tournaments & Limited Games</div>
 					<div id="queueSpawnerContent" class='visibilityToggle'>
 						<form id="queueSpawnerForm">
 							<!-- Game Type Selection -->

--- a/gemp-lotr/gemp-lotr-async/src/main/web/hall.html
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/hall.html
@@ -271,6 +271,31 @@
 							</tr>
 						</table>
 					</div>
+
+					<div id="limitedGamesHeader" class='eventHeader limitedGames'>Limited Games</div>
+					<div id="limitedGamesContent" class='visibilityToggle'>
+						<form id="limitedGameForm">
+							<!-- Game Type Selection -->
+							<label for="gameTypeSelect">Type of Game:</label>
+							<select id="gameTypeSelect" name="gameType">
+								<option value="" disabled selected>Select game type</option>
+								<option value="sealed">Sealed</option>
+								<option value="solodraft">Solo Draft</option>
+								<option value="table_draft">Live Draft</option>
+							</select>
+
+							<!-- Placeholder for dynamic fields -->
+							<div id="dynamicFields"></div>
+
+							<!-- Toggle for advanced fields -->
+							<button type="button" id="toggleAdvancedFields" style="display: none;">Show advanced settings</button>
+
+							<!-- Advanced settings section -->
+							<div id="advancedFields" style="display: none;"></div>
+
+							<button type="button" id="createTournamentButton" style="display: none;">Create</button>
+						</form>
+					</div>
 					
 				</div>
 			</div>

--- a/gemp-lotr/gemp-lotr-async/src/main/web/hall.html
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/hall.html
@@ -276,24 +276,26 @@
 					<div id="limitedGamesContent" class='visibilityToggle'>
 						<form id="limitedGameForm">
 							<!-- Game Type Selection -->
-							<label for="gameTypeSelect">Type of Game:</label>
-							<select id="gameTypeSelect" name="gameType">
-								<option value="" disabled selected>Select game type</option>
-								<option value="sealed">Sealed</option>
-								<option value="solodraft">Solo Draft</option>
-								<option value="table_draft">Live Draft</option>
-							</select>
+							<div class="formRow">
+								<label for="gameTypeSelect">Type of Game:</label>
+								<select id="gameTypeSelect" name="gameType">
+									<option value="" disabled selected>Select game type</option>
+									<option value="sealed">Sealed</option>
+									<option value="table_draft">Live Draft</option>
+									<option value="solodraft">Solo Draft</option>
+								</select>
+							</div>
 
 							<!-- Placeholder for dynamic fields -->
 							<div id="dynamicFields"></div>
 
 							<!-- Toggle for advanced fields -->
-							<button type="button" id="toggleAdvancedFields" style="display: none;">Show advanced settings</button>
+							<button type="button" id="toggleAdvancedFields" class="ui-button ui-corner-all ui-widget" style="display: none;">Show advanced settings</button>
 
 							<!-- Advanced settings section -->
 							<div id="advancedFields" style="display: none;"></div>
 
-							<button type="button" id="createTournamentButton" style="display: none;">Create</button>
+							<button type="button" id="createTournamentButton" class="ui-button ui-corner-all ui-widget" style="display: none;">Create</button>
 						</form>
 					</div>
 					

--- a/gemp-lotr/gemp-lotr-async/src/main/web/hall.html
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/hall.html
@@ -180,51 +180,6 @@
 						</table>
 					</div>
 					
-					<div id="wcQueuesHeader" class='eventHeader wc-queues'>World Championship Queues<span class='count'>(0)</span></div>
-					<div id="wcQueuesContent" class='visibilityToggle'>
-						<table class='tables wc-queues'>
-							<tr>
-								<th width='10%'>Format</th>
-								<th width='8%'>Collection</th>
-								<th width='30%'>Event Name</th>
-								<th width='16%'>Starts</th>
-								<th width='16%'>System</th>
-								<th width='8%'>Cost</th>
-								<th width='12%'>Prizes</th>
-							</tr>
-						</table>
-					</div>
-					
-					<div id="wcEventsHeader" class='eventHeader wc-events'>World Championship Events<span class='count'>(0)</span></div>
-					<div id="wcEventsContent" class='visibilityToggle'>
-						<table class='tables wc-events'>
-							<tr>
-								<th width='10%'>Format</th>
-								<th width='8%'>Collection</th>
-								<th width='20%'>Event Name</th>
-								<th width='10%'>System</th>
-								<th width='16%'>Stage</th>
-								<th width='6%'>Round</th>
-								<th width='8%'>Players</th>
-							</tr>
-						</table>
-					</div>
-
-					<div id="scheduledQueuesHeader" class='eventHeader scheduledQueues'>Scheduled Events<span class='count'>(0)</span></div>
-					<div id="scheduledQueuesContent" class='visibilityToggle'>
-						<table class='tables scheduledQueues'>
-							<tr>
-								<th width='10%'>Format</th>
-								<th width='8%'>Collection</th>
-								<th width='30%'>Event Name</th>
-								<th width='16%'>Starts</th>
-								<th width='16%'>System</th>
-								<th width='8%'>Cost</th>
-								<th width='12%'>Prizes</th>
-							</tr>
-						</table>
-					</div>
-					
 					<div id="recurringQueuesHeader" class='eventHeader recurringQueues'>Recurring Events<span class='count'>(0)</span></div>
 					<div id="recurringQueuesContent" class='visibilityToggle'>
 						<table class='tables recurringQueues'>

--- a/gemp-lotr/gemp-lotr-async/src/main/web/hall.html
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/hall.html
@@ -226,52 +226,6 @@
 						</table>
 					</div>
 
-					<div id="draftQueuesHeader" class='eventHeader draftQueues'>Draft Games<span class='count'>(0)</span></div>
-					<div id="draftQueuesContent" class='visibilityToggle'>
-						<table class='tables draftQueues'>
-							<tr>
-								<th width='10%'>Format</th>
-								<th width='8%'>Collection</th>
-								<th width='30%'>Queue name</th>
-								<th width='26%'>Starts</th>
-								<th width='10%'>System</th>
-								<th width='6%'>Players</th>
-								<th width='10%'>Actions</th>
-							</tr>
-						</table>
-					</div>
-
-					<div id="sealedQueuesHeader" class='eventHeader sealedQueues'>Sealed Games<span class='count'>(0)</span></div>
-					<div id="sealedQueuesContent" class='visibilityToggle'>
-						<table class='tables sealedQueues'>
-							<tr>
-								<th width='10%'>Format</th>
-								<th width='8%'>Collection</th>
-								<th width='30%'>Queue name</th>
-								<th width='26%'>Starts</th>
-								<th width='10%'>System</th>
-								<th width='6%'>Players</th>
-								<th width='10%'>Actions</th>
-							</tr>
-						</table>
-					</div>
-					
-					<div id="activeTournamentsHeader" class='eventHeader tournaments'>Active Tournaments<span class='count'>(0)</span></div>
-					<div id="activeTournamentsContent" class='visibilityToggle'>
-						<table class='tables tournaments'>
-							<tr>
-								<th width='10%'>Format</th>
-								<th width='10%'>Collection</th>
-								<th width='25%'>Tournament name</th>
-								<th width='15%'>System</th>
-								<th width='10%'>Stage</th>
-								<th width='10%'>Round</th>
-								<th width='10%'>Players</th>
-								<th width='10%'>Actions</th>
-							</tr>
-						</table>
-					</div>
-
 					<div id="limitedGamesHeader" class='eventHeader limitedGames'>Limited Games</div>
 					<div id="limitedGamesContent" class='visibilityToggle'>
 						<form id="limitedGameForm">

--- a/gemp-lotr/gemp-lotr-async/src/main/web/includes/admin/tournamentAdmin.html
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/includes/admin/tournamentAdmin.html
@@ -96,6 +96,18 @@ $(document).ready(
 						resultdiv.html("OK");
 					}, tourneyErrorMap(resultdiv));
 				});
+
+		$("#toggle-sealed-button").button().click(
+			function () {
+				let resultdiv = $("#toggle-sealed-result");
+				resultdiv.html("Processing...");
+
+				hall.comm.toggleSealedHallStatus(
+			   		$("#toggle-sealed-select").val(),
+					function (xml) {
+						resultdiv.html(xml);
+					}, tourneyErrorMap(resultdiv));
+			});
 		
 		$("#preview-sch-tourney-button").button().click(
 			function () {
@@ -254,9 +266,15 @@ $(document).ready(
 							.attr("value", id)
 							.text(prop + " - " + serieCount + " Series");
 						$("#sch-tourney-sealed-format").append(item);
+
+						var item2 = $("<option/>")
+							.attr("value", id)
+							.text(prop);
+						$("#toggle-sealed-select").append(item2);
 					}
 				}
 				sortOptionsByName("#sch-tourney-sealed-format");
+				sortOptionsByName("#toggle-sealed-select");
 
 				for (var prop in drafts) {
 					if (Object.prototype.hasOwnProperty.call(drafts, prop)) {
@@ -450,6 +468,37 @@ function tourneyErrorMap(outputControl, callback=null) {
 				<b>Result:</b>
 			</div>
 			<div id="update-stage-result" class="flex-fill result-box">
+				Ready.
+			</div>
+		</div>
+	</div>
+
+	<br/><br/><hr><br/><br/>
+
+	<div id="toggle-sealed-hall-section" class="league-form">
+		<h1>Toggle Sealed Format Hall Status</h1>
+
+		<div class="flex-horiz">
+			<div class="label-column">Sealed Format: </div>
+			<select id="toggle-sealed-select" class="flex-fill"></select>
+		</div>
+
+		<div>
+			<p>If chosen sealed format is already available in hall, this will disable it. If the format is not available
+			in hall, this will enable it.</p>
+			<p>The changes made using this form are in effect only until server restart or json definitions reload.</p>
+			<p>For permanent change, remove or add "hall: true" field in the sealed format json definition.</p>
+		</div>
+
+		<button id="toggle-sealed-button">
+			Toggle Sealed Format Hall Status
+		</button>
+
+		<div id=toggle-sealed-result-label" class="flex-horiz result-label">
+			<div class="label">
+				<b>Result:</b>
+			</div>
+			<div id="toggle-sealed-result" class="flex-fill result-box">
 				Ready.
 			</div>
 		</div>

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/communication.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/communication.js
@@ -1433,5 +1433,37 @@ var GempLotrCommunication = Class.extend({
             error:this.errorCheck(errorMap),
             dataType:"xml"
         });
+    },
+    getLimitedTournamentAvailableFormats:function (callback, errorMap) {
+        $.ajax({
+            type:"GET",
+            url:this.url + "/tournament/limitedFormats",
+            cache:false,
+            success:this.deliveryCheck(callback),
+            error:this.errorCheck(errorMap),
+            dataType:"json"
+        });
+    },
+    createTournament:function (type, maxPlayers, sealedFormatCode, soloDraftFormatCode, tableDraftFormatCode, tableDraftTimer,
+                               playoff, deckbuildingDuration, callback, errorMap) {
+        $.ajax({
+            type:"POST",
+            url:this.url + "/tournament/create",
+            cache:false,
+            data:{
+                type:type,
+                maxPlayers:maxPlayers,
+                sealedFormatCode:sealedFormatCode,
+                soloDraftFormatCode:soloDraftFormatCode,
+                tableDraftFormatCode:tableDraftFormatCode,
+                tableDraftTimer:tableDraftTimer,
+                playoff:playoff,
+                deckbuildingDuration:deckbuildingDuration,
+                participantId:getUrlParam("participantId")
+            },
+            success:this.deliveryCheck(callback),
+            error:this.errorCheck(errorMap),
+            dataType:"json"
+        });
     }
 });

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/communication.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/communication.js
@@ -1445,7 +1445,7 @@ var GempLotrCommunication = Class.extend({
         });
     },
     createTournament:function (type, maxPlayers, sealedFormatCode, soloDraftFormatCode, tableDraftFormatCode, tableDraftTimer,
-                               playoff, deckbuildingDuration, competitive, callback, errorMap) {
+                               playoff, deckbuildingDuration, competitive, startable, callback, errorMap) {
         $.ajax({
             type:"POST",
             url:this.url + "/tournament/create",
@@ -1460,6 +1460,7 @@ var GempLotrCommunication = Class.extend({
                 playoff:playoff,
                 deckbuildingDuration:deckbuildingDuration,
                 competitive:competitive,
+                startable:startable,
                 participantId:getUrlParam("participantId")
             },
             success:this.deliveryCheck(callback),

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/communication.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/communication.js
@@ -1434,17 +1434,17 @@ var GempLotrCommunication = Class.extend({
             dataType:"xml"
         });
     },
-    getLimitedTournamentAvailableFormats:function (callback, errorMap) {
+    getTournamentAvailableFormats:function (callback, errorMap) {
         $.ajax({
             type:"GET",
-            url:this.url + "/tournament/limitedFormats",
+            url:this.url + "/tournament/tournamentFormats",
             cache:false,
             success:this.deliveryCheck(callback),
             error:this.errorCheck(errorMap),
             dataType:"json"
         });
     },
-    createTournament:function (type, maxPlayers, sealedFormatCode, soloDraftFormatCode, tableDraftFormatCode, tableDraftTimer,
+    createTournament:function (type, deckName, maxPlayers, constructedFormatCode, sealedFormatCode, soloDraftFormatCode, tableDraftFormatCode, tableDraftTimer,
                                playoff, deckbuildingDuration, competitive, startable, readyCheck, callback, errorMap) {
         $.ajax({
             type:"POST",
@@ -1452,7 +1452,9 @@ var GempLotrCommunication = Class.extend({
             cache:false,
             data:{
                 type:type,
+                deckName:deckName,
                 maxPlayers:maxPlayers,
+                constructedFormatCode:constructedFormatCode,
                 sealedFormatCode:sealedFormatCode,
                 soloDraftFormatCode:soloDraftFormatCode,
                 tableDraftFormatCode:tableDraftFormatCode,

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/communication.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/communication.js
@@ -1445,7 +1445,7 @@ var GempLotrCommunication = Class.extend({
         });
     },
     createTournament:function (type, maxPlayers, sealedFormatCode, soloDraftFormatCode, tableDraftFormatCode, tableDraftTimer,
-                               playoff, deckbuildingDuration, callback, errorMap) {
+                               playoff, deckbuildingDuration, competitive, callback, errorMap) {
         $.ajax({
             type:"POST",
             url:this.url + "/tournament/create",
@@ -1459,6 +1459,7 @@ var GempLotrCommunication = Class.extend({
                 tableDraftTimer:tableDraftTimer,
                 playoff:playoff,
                 deckbuildingDuration:deckbuildingDuration,
+                competitive:competitive,
                 participantId:getUrlParam("participantId")
             },
             success:this.deliveryCheck(callback),

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/communication.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/communication.js
@@ -1470,5 +1470,18 @@ var GempLotrCommunication = Class.extend({
             error:this.errorCheck(errorMap),
             dataType:"json"
         });
-    }
+    },
+	toggleSealedHallStatus:function (sealedFormatCode, callback, errorMap) {
+		$.ajax({
+			type:"POST",
+			url:this.url + "/admin/toggleSealedHallStatus",
+			cache:false,
+			data:{
+				sealedFormatCode:sealedFormatCode
+			},
+			success:callback,
+			error:this.errorCheck(errorMap),
+			dataType:"html"
+		});
+	}
 });

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/communication.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/communication.js
@@ -1445,7 +1445,7 @@ var GempLotrCommunication = Class.extend({
         });
     },
     createTournament:function (type, maxPlayers, sealedFormatCode, soloDraftFormatCode, tableDraftFormatCode, tableDraftTimer,
-                               playoff, deckbuildingDuration, competitive, startable, callback, errorMap) {
+                               playoff, deckbuildingDuration, competitive, startable, readyCheck, callback, errorMap) {
         $.ajax({
             type:"POST",
             url:this.url + "/tournament/create",
@@ -1461,6 +1461,7 @@ var GempLotrCommunication = Class.extend({
                 deckbuildingDuration:deckbuildingDuration,
                 competitive:competitive,
                 startable:startable,
+                readyCheck:readyCheck,
                 participantId:getUrlParam("participantId")
             },
             success:this.deliveryCheck(callback),

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -261,6 +261,10 @@ var GempLotrHallUI = Class.extend({
                 if (gameType === "table_draft" && format.maxPlayers) {
                     $option.attr("data-maxplayers", format.maxPlayers);
                 }
+                // And recommended timer
+                if (gameType === "table_draft" && format.recommendedTimer) {
+                    $option.attr("data-recommendedtimer", format.recommendedTimer);
+                }
 
                 $select.append($option);
             }
@@ -332,24 +336,6 @@ var GempLotrHallUI = Class.extend({
                 $("<div>").append($playersInput)
             );
 
-            // Add live draft timer
-            const $timerLabel = $("<label>").attr("for", "draftTimer").text("Draft timer:");
-            const $timerSelect = $("<select>")
-                .attr({ id: "draftTimer", name: "draftTimer" })
-                .append($("<option disabled selected>").text("Select timer"));
-            if (gameType === "table_draft") {
-                for (const timerType of json.draftTimerTypes) {
-                    $timerSelect.append(
-                        $("<option>").val(timerType).text(timerType.replace("_", " ").toLowerCase().replace(/\b\w/g, c => c.toUpperCase()))
-                    );
-                }
-
-                $fields.append(
-                    $("<div>").append($timerLabel),
-                    $("<div>").append($timerSelect)
-                );
-            }
-
             // Append to form
             $advanced.append(
                 $("<div>").append($pairingLabel),
@@ -363,6 +349,34 @@ var GempLotrHallUI = Class.extend({
                 $("<div>").append($readyCheckLabel),
                 $("<div>").append($readyCheckSelect)
             );
+
+            // Add live draft timer
+            const $timerLabel = $("<label>").attr("for", "draftTimer").text("Draft timer:");
+            const $timerSelect = $("<select>")
+                .attr({ id: "draftTimer", name: "draftTimer" })
+                .append($("<option disabled selected>").text("Select timer"));
+            if (gameType === "table_draft") {
+                for (const timerType of json.draftTimerTypes) {
+                    $timerSelect.append(
+                        $("<option>").val(timerType).text(timerType.replace("_", " ").toLowerCase().replace(/\b\w/g, c => c.toUpperCase()))
+                    );
+                }
+
+                $advanced.append(
+                    $("<div>").append($timerLabel),
+                    $("<div>").append($timerSelect)
+                );
+
+                // Modify the timer based on format selected
+                $select.on("change", function () {
+                    const selectedFormat = $(this).find("option:selected");
+                    const recommendedTimer = selectedFormat.data("recommendedtimer");
+
+                    if (recommendedTimer) {
+                        $timerSelect.val(recommendedTimer);
+                    }
+                });
+            }
 
             // Add validating listeners
             $select.on("change", validateTournamentForm);

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -209,6 +209,10 @@ var GempLotrHallUI = Class.extend({
             $toggleAdvanced.off("click").on("click", function () {
                 advancedVisible = !advancedVisible;
                 $advanced.toggle(advancedVisible);
+                if (advancedVisible) {
+                    // Scroll to bottom so that the new field can be seen
+                    $("#limitedGameForm").get(0).scrollIntoView({ behavior: "smooth", block: "end" });
+                }
                 $(this).text(advancedVisible ? "Hide advanced settings" : "Show advanced settings");
             });
 
@@ -255,6 +259,13 @@ var GempLotrHallUI = Class.extend({
                 .append($("<option>").val("SWISS").text("Swiss"))
                 .append($("<option>").val("SINGLE_ELIMINATION").text("Single elimination"));
 
+            // Competitive
+            const $competitiveLabel = $("<label>").attr("for", "competitiveSelect").text("Competitive:");
+            const $competitiveSelect = $("<select>")
+                .attr({ id: "competitiveSelect", name: "competitive" })
+                .append($("<option>").val("false").text("Games can be spectated"))
+                .append($("<option>").val("true").text("No spectate; hidden names in queue"));
+
             // Deck-building duration
             const $durationLabel = $("<label>").attr("for", "deckDuration").text("Deck-building duration (minutes, minimum 5):");
             const $durationInput = $("<input>")
@@ -292,7 +303,9 @@ var GempLotrHallUI = Class.extend({
                 $("<div>").append($pairingLabel),
                 $("<div>").append($pairingSelect),
                 $("<div>").append($durationLabel),
-                $("<div>").append($durationInput)
+                $("<div>").append($durationInput),
+                $("<div>").append($competitiveLabel),
+                $("<div>").append($competitiveSelect)
             );
 
             // Add validating listeners
@@ -340,6 +353,9 @@ var GempLotrHallUI = Class.extend({
             // Pairing
             const playoff = $("#pairingType").val();
 
+            const competitive = $("#competitiveSelect").val();
+
+
             // Deck building duration (number input)
             const deckbuildingDuration = parseInt($("#deckDuration").val(), 10) || 15;
             const maxPlayers = parseInt($("#numPlayers").val(), 10) || 4;
@@ -354,6 +370,7 @@ var GempLotrHallUI = Class.extend({
                 tableDraftTimer,
                 playoff,
                 deckbuildingDuration,
+                competitive,
                 function(json) {
                     // Success callback — handle your response here
                     console.log("Tournament created successfully:", json);

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -212,7 +212,13 @@ var GempLotrHallUI = Class.extend({
                 validPlayerReadyCombo &&
                 draftValid;
 
-            $("#createTournamentButton").prop("disabled", !allValid);
+            if (allValid) {
+                $("#createTournamentButton").prop("disabled", false);
+                $("#createTournamentButton").removeClass("ui-state-disabled");
+            } else {
+                $("#createTournamentButton").prop("disabled", true);
+                $("#createTournamentButton").addClass("ui-state-disabled");
+            }
         };
 
         $("#gameTypeSelect").on("change", function () {
@@ -245,13 +251,15 @@ var GempLotrHallUI = Class.extend({
             if (formats.length === 0) return;
 
             // Create Format label and select
+            const $formatRow = $("<div>").addClass("formRow");
             const $label = $("<label>").attr("for", "formatSelect").text("Format:");
             const $select = $("<select>")
               .attr("id", "formatSelect")
               .attr("name", "format")
               .append($("<option disabled selected>").text("Select format"));
+            $formatRow.append($label, $select);
 
-            // Fill options
+            // Fill format options
             for (const format of formats) {
                 const $option = $("<option>")
                     .val(format.code)
@@ -270,10 +278,12 @@ var GempLotrHallUI = Class.extend({
             }
 
             // Number of players
+            const $playersRow = $("<div>").addClass("formRow");
             const $playersLabel = $("<label>").attr("for", "numPlayers").text("Number of players:");
             const $playersInput = $("<input>")
                 .attr({ type: "number", id: "numPlayers", name: "numPlayers", min: 1 })
                 .val(4);
+            $playersRow.append($playersLabel, $playersInput);
 
             // Modify the max number of players based on format selected (if needed)
             $select.on("change", function () {
@@ -292,69 +302,75 @@ var GempLotrHallUI = Class.extend({
             });
 
             // Pairing type
+            const $pairingRow = $("<div>").addClass("formRow");
             const $pairingLabel = $("<label>").attr("for", "pairingType").text("Pairing type:");
             const $pairingSelect = $("<select>")
                 .attr({ id: "pairingType", name: "pairingType" })
-                .append($("<option>").val("SWISS").text("Swiss"))
+                .append($("<option>").val("SWISS").text("Swiss - losers play next rounds too"))
                 .append($("<option>").val("SINGLE_ELIMINATION").text("Single elimination"));
+            $pairingRow.append($pairingLabel, $pairingSelect);
 
             // Deck-building duration
+            const $durationRow = $("<div>").addClass("formRow");
             const $durationLabel = $("<label>").attr("for", "deckDuration").text("Deck-building duration (minutes, minimum 5):");
             const $durationInput = $("<input>")
                 .attr({ type: "number", id: "deckDuration", name: "deckDuration", min: 5 })
                 .val(15);
+            $durationRow.append($durationLabel, $durationInput);
 
             // Competitive
+            const $competitiveRow = $("<div>").addClass("formRow");
             const $competitiveLabel = $("<label>").attr("for", "competitiveSelect").text("Competitive:");
             const $competitiveSelect = $("<select>")
                 .attr({ id: "competitiveSelect", name: "competitive" })
                 .append($("<option>").val("false").text("Games can be spectated"))
                 .append($("<option>").val("true").text("No spectate; hidden names in queue"));
+            $competitiveRow.append($competitiveLabel, $competitiveSelect);
 
             // Early start
+            const $earlyStartRow = $("<div>").addClass("formRow");
             const $earlyStartLabel = $("<label>").attr("for", "startableEarlySelect").text("Early start:");
             const $earlyStartSelect = $("<select>")
                 .attr({ id: "startableEarlySelect", name: "startableEarly" })
                 .append($("<option>").val("true").text("Can be started with less players"))
                 .append($("<option>").val("false").text("Starts only with all player slots filled"));
+            $earlyStartRow.append($earlyStartLabel, $earlyStartSelect);
 
             // Ready check
+            const $readyCheckRow = $("<div>").addClass("formRow");
             const $readyCheckLabel = $("<label>").attr("for", "readyCheckSelect").text("Ready check:");
             const $readyCheckSelect = $("<select>")
                 .attr({ id: "readyCheckSelect", name: "readyCheck" })
-                .append($("<option>").val("-1").text("No ready check, just start the tournament"))
-                .append($("<option>").val("90").text("90 seconds to confirm"))
+                .append($("<option>").val("-1").text("No, just start the tournament"))
+                .append($("<option>").val("60").text("1 minute to confirm"))
+                .append($("<option>").val("90").text("1 minute 30 seconds to confirm"))
                 .append($("<option>").val("180").text("3 minutes to confirm"));
+            $readyCheckRow.append($readyCheckLabel, $readyCheckSelect);
             // Set default to 90 seconds as we start with 4 players
             $readyCheckSelect.val("90");
 
             // Append to form
             $fields.append(
-                $("<div>").append($label),
-                $("<div>").append($select),
-                $("<div>").append($playersLabel),
-                $("<div>").append($playersInput)
+                $("<div>").append($formatRow),
+                $("<div>").append($playersRow)
             );
 
             // Append to form
             $advanced.append(
-                $("<div>").append($pairingLabel),
-                $("<div>").append($pairingSelect),
-                $("<div>").append($durationLabel),
-                $("<div>").append($durationInput),
-                $("<div>").append($competitiveLabel),
-                $("<div>").append($competitiveSelect),
-                $("<div>").append($earlyStartLabel),
-                $("<div>").append($earlyStartSelect),
-                $("<div>").append($readyCheckLabel),
-                $("<div>").append($readyCheckSelect)
+                $("<div>").append($pairingRow),
+                $("<div>").append($durationRow),
+                $("<div>").append($competitiveRow),
+                $("<div>").append($earlyStartRow),
+                $("<div>").append($readyCheckRow)
             );
 
             // Add live draft timer
+            const $timerRow = $("<div>").addClass("formRow");
             const $timerLabel = $("<label>").attr("for", "draftTimer").text("Draft timer:");
             const $timerSelect = $("<select>")
                 .attr({ id: "draftTimer", name: "draftTimer" })
                 .append($("<option disabled selected>").text("Select timer"));
+            $timerRow.append($timerLabel, $timerSelect);
             if (gameType === "table_draft") {
                 for (const timerType of json.draftTimerTypes) {
                     $timerSelect.append(
@@ -363,8 +379,7 @@ var GempLotrHallUI = Class.extend({
                 }
 
                 $advanced.append(
-                    $("<div>").append($timerLabel),
-                    $("<div>").append($timerSelect)
+                    $("<div>").append($timerRow)
                 );
 
                 // Modify the timer based on format selected

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -1144,7 +1144,7 @@ var GempLotrHallUI = Class.extend({
 					tablesRow.append("<td>" + queue.getAttribute("format") + "</td>");
 					let htmlTd = "<td>";
 					if (isWC) {
-						htmlTd += "WC";
+						htmlTd += "World Championship";
 					} else {
 						// For system, ignore all after ',' (min players)
 						htmlTd += queue.getAttribute("system").split(',')[0] + " Tournament";
@@ -1160,8 +1160,9 @@ var GempLotrHallUI = Class.extend({
 					tablesRow.append(actionsField);
 					if (joined == "true") {
 						tablesRow.addClass("played");
-					} else if (isWC) {
-						tablesRow.addClass("wc-events");
+					}
+					if (isWC) {
+						tablesRow.addClass("bold");
 					}
 
 					if (action == "add") {
@@ -1391,7 +1392,11 @@ var GempLotrHallUI = Class.extend({
 					}
 					var tablesRow = $("<tr class='table" + id + "'></tr>");
 					tablesRow.append("<td>" + tournament.getAttribute("format") + "</td>");
-					tablesRow.append("<td>" + tournament.getAttribute("system") + " Tournament - " + displayType + " - " + tournament.getAttribute("name") + "</td>");
+					if (isWC) {
+						tablesRow.append("<td>World Championship - " + displayType + " - " + tournament.getAttribute("name") + "</td>");
+					} else {
+						tablesRow.append("<td>" + tournament.getAttribute("system") + " Tournament - " + displayType + " - " + tournament.getAttribute("name") + "</td>");
+					}
 					if (tournament.hasAttribute("timeRemaining")) {
 						tablesRow.append("<td>" + tournament.getAttribute("stage") + " - " + tournament.getAttribute("timeRemaining") + "</td>");
 					} else if (tournament.getAttribute("stage") === "Playing Games") {
@@ -1399,12 +1404,17 @@ var GempLotrHallUI = Class.extend({
 					} else {
 						tablesRow.append("<td>" + tournament.getAttribute("stage") + "</td>");
 					}
-					tablesRow.append("<td>" + tournament.getAttribute("playerList") + "</td>");
+					if (tournament.getAttribute("playerCount") <= 8) {
+						tablesRow.append("<td>" + tournament.getAttribute("playerList") + "</td>");
+					} else {
+						tablesRow.append("<td><div class='prizeHint' title='Competing Players' value='" + tournament.getAttribute("playerList") + "<br><br>* = abandoned'>" + tournament.getAttribute("playerCount") + "</div></td>");
+					}
 					tablesRow.append(actionsField);
 					if (joined == "true") {
-						tablesRow.addClass("played"); // red highlight
-					} else if (isWC) {
-						tablesRow.addClass("wc-events"); // yellow highlight
+						tablesRow.addClass("played");
+					}
+					if (isWC) {
+						tablesRow.addClass("bold");
 					}
 
 					if (action == "add") {

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -239,20 +239,25 @@ var GempLotrHallUI = Class.extend({
 		}
 
 		// Look ahead for any section that should come after this one
+		let inserted = false;
+
 		for (let i = index + 1; i < sectionOrder.length; i++) {
 			const $nextContent = $("#" + sectionIds[sectionOrder[i]]);
 			if ($nextContent.length) {
-				const $nextHeader = $("#" + sectionOrder[i] + "Header");
+			const $nextHeader = $("#" + sectionOrder[i] + "Header");
 				$header.insertBefore($nextHeader);
 				$content.insertBefore($nextHeader);
-				return;
+				inserted = true;
+				break;
 			}
 		}
 
 		// Fallback insert
-		const $anchor = $("#recurringQueuesHeader");
-		$header.insertBefore($anchor);
-		$content.insertBefore($anchor);
+		if (!inserted) {
+			const $anchor = $("#recurringQueuesHeader");
+			$header.insertBefore($anchor);
+			$content.insertBefore($anchor);
+        }
 
 		// Load settings
 		let hallSettingsStr = $.cookie("hallSettings") || "1|1|0|0|0|0|0";

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -118,18 +118,14 @@ var GempLotrHallUI = Class.extend({
 
 		var hallSettingsStr = $.cookie("hallSettings");
 		if (hallSettingsStr == null)
-			hallSettingsStr = "1|1|0|0|0|0|0|0";
+			hallSettingsStr = "1|1|0|0|0|0|0";
 		var hallSettings = hallSettingsStr.split("|");
 
 		this.initTable(hallSettings[0] == "1", "waitingTablesHeader", "waitingTablesContent");
 		this.initTable(hallSettings[1] == "1", "playingTablesHeader", "playingTablesContent");
 		this.initTable(hallSettings[2] == "1", "finishedTablesHeader", "finishedTablesContent");
-		// Those 3 indexes are applied dynamically if there is some data for those sections
-//		this.initTable(hallSettings[3] == "1", "wcQueuesHeader", "wcQueuesContent");
-//		this.initTable(hallSettings[4] == "1", "wcEventsHeader", "wcEventsContent");
-//		this.initTable(hallSettings[5] == "1", "scheduledQueuesHeader", "scheduledQueuesContent");
-		this.initTable(hallSettings[6] == "1", "recurringQueuesHeader", "recurringQueuesContent");
-		this.initTable(hallSettings[7] == "1", "queueSpawnerHeader", "queueSpawnerContent");
+		this.initTable(hallSettings[5] == "1", "recurringQueuesHeader", "recurringQueuesContent");
+		this.initTable(hallSettings[6] == "1", "queueSpawnerHeader", "queueSpawnerContent");
 
 		$("#deckbuilder-button").button();
 		$("#bug-button").button();
@@ -197,34 +193,6 @@ var GempLotrHallUI = Class.extend({
         this.insertEventSection($header, $content, "wcQueues");
     },
 
-    addWcEventsSection: function() {
-        if ($("#wcEventsHeader").length) return;
-
-        const $header = $("<div>")
-            .attr("id", "wcEventsHeader")
-            .addClass("eventHeader wc-events")
-            .html(`World Championship Events<span class='count'>(0)</span>`);
-
-        const $content = $("<div>")
-            .attr("id", "wcEventsContent")
-            .addClass("visibilityToggle")
-            .append(
-                $("<table>").addClass("tables wc-events").append(`
-                    <tr>
-                        <th width='10%'>Format</th>
-                        <th width='8%'>Collection</th>
-                        <th width='20%'>Event Name</th>
-                        <th width='10%'>System</th>
-                        <th width='16%'>Stage</th>
-                        <th width='6%'>Round</th>
-                        <th width='8%'>Players</th>
-                    </tr>
-                `)
-            );
-
-        this.insertEventSection($header, $content, "wcEvents");
-    },
-
     addScheduledQueuesSection: function() {
         if ($("#scheduledQueuesHeader").length) return;
 
@@ -256,13 +224,11 @@ var GempLotrHallUI = Class.extend({
     insertEventSection: function($header, $content, sectionKey) {
         const sectionOrder = [
 			"wcQueues",
-			"wcEvents",
 			"scheduledQueues"
 		];
 
 		const sectionIds = {
 			wcQueues: "wcQueuesContent",
-			wcEvents: "wcEventsContent",
 			scheduledQueues: "scheduledQueuesContent"
 		};
 
@@ -300,10 +266,8 @@ var GempLotrHallUI = Class.extend({
 
 		if (headerId === "wcQueuesHeader" && contentId === "wcQueuesContent") {
 			settingIndex = 3;
-		} else if (headerId === "wcEventsHeader" && contentId === "wcEventsContent") {
-			settingIndex = 4;
 		} else if (headerId === "scheduledQueuesHeader" && contentId === "scheduledQueuesContent") {
-			settingIndex = 5;
+			settingIndex = 4;
 		}
 
 		if (settingIndex !== null) {
@@ -314,11 +278,6 @@ var GempLotrHallUI = Class.extend({
     removeWcQueuesSection: function() {
         $("#wcQueuesHeader").remove();
         $("#wcQueuesContent").remove();
-    },
-
-    removeWcEventsSection: function() {
-        $("#wcEventsHeader").remove();
-        $("#wcEventsContent").remove();
     },
 
     removeScheduledQueuesSection: function() {
@@ -713,14 +672,13 @@ var GempLotrHallUI = Class.extend({
 			"playingTablesContent",
 			"finishedTablesContent",
 			"wcQueuesContent",
-			"wcEventsContent",
 			"scheduledQueuesContent",
 			"recurringQueuesContent",
 			"queueSpawnerContent"
 		];
 
 		// Load current cookie (or use default if missing)
-		let hallSettingsStr = $.cookie("hallSettings") || "1|1|0|0|0|0|0|0";
+		let hallSettingsStr = $.cookie("hallSettings") || "1|1|0|0|0|0|0";
 		let currentSettings = hallSettingsStr.split("|");
 
 		// Update only if the element exists
@@ -1343,36 +1301,6 @@ var GempLotrHallUI = Class.extend({
 						}
 					}
 
-					// Tournament for for tournament table (not in Playing Tables Section)
-					var rowstr = "";
-					rowstr += "<tr class='tournament" + id + "'><td>" + tournament.getAttribute("format") + "</td>";
-					if(type === "sealed") {
-						rowstr += "<td>Sealed</td>";
-					}
-					else if (type === "solodraft") {
-						rowstr += "<td>Solo Draft</td>";
-
-					}
-					else if (type === "table_solodraft") {
-						rowstr += "<td>Solo Table Draft</td>";
-					}
-					else if (type === "table_draft") {
-						rowstr += "<td>Table Draft</td>";
-					}
-					else {
-						rowstr += "<td>" + tournament.getAttribute("collection") + "</td>";
-					}
-					rowstr += "<td>" + tournament.getAttribute("name") + "</td>" +
-						"<td>" + tournament.getAttribute("system") + "</td>";
-					if (tournament.hasAttribute("timeRemaining")) {
-						rowstr += "<td>" + tournament.getAttribute("stage") + " - " + tournament.getAttribute("timeRemaining") + "</td>";
-					} else {
-						rowstr += "<td>" + tournament.getAttribute("stage") + "</td>";
-					}
-					rowstr += "<td>" + tournament.getAttribute("round") + "</td>" +
-						"<td><div class='prizeHint' title='Competing Players' value='" + tournament.getAttribute("playerList") + "<br><br>* = abandoned'>" + tournament.getAttribute("playerCount") + "</div></td></tr>";
-					var row = $(rowstr);
-
 					// Row for tournament playing table
 					var displayType = type;
 					if(type === "sealed") {
@@ -1418,13 +1346,7 @@ var GempLotrHallUI = Class.extend({
 					}
 
 					if (action == "add") {
-						// Right now the only tournament section is for WC events
-						if (isWC) {
-							that.addWcEventsSection();
-							$("table.wc-events", this.tablesDiv)
-							.append(row);
-						}
-						// Display running tournaments also as playing tables
+						// Display running tournaments as playing tables
 						$("table.playingTables", this.tablesDiv)
 							.append(tablesRow)
 
@@ -1443,9 +1365,6 @@ var GempLotrHallUI = Class.extend({
 						}
 
 					} else if (action == "update") {
-						// Update row in tournaments sections
-						$(".tournament" + id, this.tablesDiv).replaceWith(row);
-
 						// Update row in playing tables section
 						var existingRow = $(".table" + id, this.tablesDiv);
 						if (existingRow.length > 0) {
@@ -1459,14 +1378,8 @@ var GempLotrHallUI = Class.extend({
 
 					this.animateRowUpdate(".tournament" + id);
 				} else if (action == "remove") {
-					// Remove tournament both from playing tables section and tournament sections
-					$(".tournament" + id, this.tablesDiv).remove();
 					$(".table" + id, this.tablesDiv).remove();
 				}
-			}
-			
-			if($('.wc-events tr').length <= 1) {
-				that.removeWcEventsSection();
 			}
 
 			var tables = root.getElementsByTagName("table");
@@ -1661,7 +1574,6 @@ var GempLotrHallUI = Class.extend({
 			$(".count", $(".eventHeader.finishedTables")).html("(" + ($("tr", $("table.finishedTables")).length - 1) + ")");
 
 			$(".count", $(".eventHeader.wc-queues")).html("(" + ($("tr", $("table.wc-queues")).length - 1) + ")");
-			$(".count", $(".eventHeader.wc-events")).html("(" + ($("tr", $("table.wc-events")).length - 1) + ")");
 
 			var games = root.getElementsByTagName("newGame");
 			for (var i=0; i<games.length; i++) {

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -126,14 +126,10 @@ var GempLotrHallUI = Class.extend({
 		this.initTable(hallSettings[2] == "1", "finishedTablesHeader", "finishedTablesContent");
 		this.initTable(hallSettings[3] == "1", "wcQueuesHeader", "wcQueuesContent");
 		this.initTable(hallSettings[4] == "1", "wcEventsHeader", "wcEventsContent");
-		this.initTable(hallSettings[5] == "1", "tournamentQueuesHeader", "tournamentQueuesContent");
-		this.initTable(hallSettings[6] == "1", "queueSpawnerHeader", "queueSpawnerContent");
-		
-		$('#wcQueuesHeader').hide();
-		$('#wcQueuesContent').hide();
-		$('#wcEventsHeader').hide();
-		$('#wcEventsContent').hide();
-		
+		this.initTable(hallSettings[5] == "1", "scheduledQueuesHeader", "scheduledQueuesContent");
+		this.initTable(hallSettings[6] == "1", "recurringQueuesHeader", "recurringQueuesContent");
+		this.initTable(hallSettings[7] == "1", "queueSpawnerHeader", "queueSpawnerContent");
+
 		$("#deckbuilder-button").button();
 		$("#bug-button").button();
 		$("#report-button").button();
@@ -543,7 +539,7 @@ var GempLotrHallUI = Class.extend({
 				return $(visibilityToggle[index]).hasClass("hidden") ? "0" : "1";
 			};
 
-		var newHallSettings = getSettingValue(0) + "|" + getSettingValue(1) + "|" + getSettingValue(2) + "|" + getSettingValue(3) + "|" + getSettingValue(4)+ "|" + getSettingValue(5) + "|" + getSettingValue(6) + "|" + getSettingValue(7) + "|" + getSettingValue(8);
+		var newHallSettings = getSettingValue(0) + "|" + getSettingValue(1) + "|" + getSettingValue(2) + "|" + getSettingValue(3) + "|" + getSettingValue(4)+ "|" + getSettingValue(5) + "|" + getSettingValue(6) + "|" + getSettingValue(7);
 		console.log("New settings: " + newHallSettings);
 		$.cookie("hallSettings", newHallSettings, { expires:365 });
 	},
@@ -755,6 +751,9 @@ var GempLotrHallUI = Class.extend({
 				var queue = queues[i];
 				var id = queue.getAttribute("id");
 				var isWC = queue.getAttribute("wc") == "true";
+				var isRecurring = queue.getAttribute("recurring") == "true";
+				var isScheduled = queue.getAttribute("scheduled") == "true";
+				var displayInWaitingTables = queue.getAttribute("displayInWaitingTables") == "true";
 				var action = queue.getAttribute("action");
 				if (action == "add" || action == "update") {
 					var actionsField = $("<td></td>");
@@ -772,7 +771,7 @@ var GempLotrHallUI = Class.extend({
 									
 									var queueId = queueInfo.getAttribute("id");
 									var type = queueInfo.getAttribute("type");
-									if(type !== null)
+									if (type !== null)
 										type = type.toLowerCase();
 									var queueName = queueInfo.getAttribute("queue");
 									var queueStart = queueInfo.getAttribute("start");
@@ -788,36 +787,35 @@ var GempLotrHallUI = Class.extend({
 											if(type === "sealed") {
 												message = "You have signed up to participate in the <b>" + queueName
 											 + "</b> tournament.<br><br>When the event begins, you will be issued sealed packs to open and make a deck. " +
-											 "At any time during the deckbuilding phase and for a short time after it ends, you will need to lock-in your deck before the tournament begins.<br><br>" +
-											 "Deckbuilding begins at " + queueStart + ".	Good luck!";
+											 "At any time during the deck building phase, you will need to lock-in your deck before the tournament begins.<br><br>" +
+											 "Deck building begins at " + queueStart + ".	Good luck!";
 											}
 
 											if(type === "solodraft") {
 												message = "You have signed up to participate in the <b>" + queueName
-											 + "</b> tournament.<br><br>When the event begins, use the 'Go to Draft' button in the Active Tournaments Section, and then build your deck in the Deck Builder. " +
-											 "At any time during the deckbuilding phase and for a short time after it ends, you will need to lock-in your deck before the tournament begins.<br><br>" +
-											 "Deckbuilding begins at " + queueStart + ".	Good luck!";
+											 + "</b> tournament.<br><br>When the event begins, use the 'Go to Draft' button in the Playing Tables Section, and then build your deck in the Deck Builder. " +
+											 "At any time during the deck building phase, you will need to lock-in your deck before the tournament begins.<br><br>" +
+											 "Deck building begins at " + queueStart + ".	Good luck!";
 											}
 
 											if(type === "table_solodraft") {
 												message = "You have signed up to participate in the <b>" + queueName
-											 + "</b> tournament.<br><br>When the event begins, use the 'Go to Draft' button in the Active Tournaments Section, and then build your deck in the Deck Builder. " +
-											 "At any time during the deckbuilding phase and for a short time after it ends, you will need to lock-in your deck before the tournament begins.<br><br>" +
-											 "Deckbuilding begins at " + queueStart + ".	Good luck!";
+											 + "</b> tournament.<br><br>When the event begins, use the 'Go to Draft' button in the Playing Tables Section, and then build your deck in the Deck Builder. " +
+											 "At any time during the deck building phase, you will need to lock-in your deck before the tournament begins.<br><br>" +
+											 "Deck building begins at " + queueStart + ".	Good luck!";
 											}
 
 											if(type === "table_draft") {
 												message = "You have signed up to participate in the <b>" + queueName
-											 + "</b> tournament.<br><br>When the event begins, use the 'Go to Draft' button in the Active Tournaments Section, and then build your deck in the Deck Builder. " +
-											 "At any time during the deckbuilding phase and for a short time after it ends, you will need to lock-in your deck before the tournament begins.<br><br>" +
+											 + "</b> tournament.<br><br>When the event begins, use the 'Go to Draft' button in the Playing Tables Section, and then build your deck in the Deck Builder. " +
+											 "At any time during the deck building phase, you will need to lock-in your deck before the tournament begins.<br><br>" +
 											 "Draft begins at " + queueStart + ".	Good luck!";
 											}
 											that.showDialog("Joined Tournament", message, 320);
 										}
 									}, that.hallErrorMap());
 								};
-							}
-							)(queue));
+							})(queue));
 						actionsField.append(but);
 					} else if (joined == "true") {
 						that.inTournament = true;
@@ -833,8 +831,6 @@ var GempLotrHallUI = Class.extend({
 										
 										if(result) {
 											that.inTournament = false;
-											that.showDialog("Left Tournament", "You have been removed from the <b>" + queueName
-											 + "</b> tournament.<br><br>If you wish to rejoin, you will need to requeue before it starts at " + queueStart + ".", 230);
 										}
 									});
 								}
@@ -855,10 +851,10 @@ var GempLotrHallUI = Class.extend({
 							actionsField.append(startBut);
 						}
 
-						if (+queue.getAttribute("readyCheckSecsRemaining") > -1) {
+						if (+queue.getAttribute("readyCheckSecsRemaining") > -1) { // The '+' sign converts string to number
 							if ($("button:contains('READY CHECK')").length === 0 && queue.getAttribute("confirmedReadyCheck") == "false") {
 								that.showDialog("Ready Check", "Ready Check started for the <b>" + queue.getAttribute("queue")
-									+ "</b> tournament.<br><br>To confirm you are present, click the Ready Check button within next "
+									+ "</b> tournament.<br><br>To confirm you are present, click the Ready Check button in the Waiting Tables Section within the next "
 									+ queue.getAttribute("readyCheckSecsRemaining") + " seconds.", 230);
 							}
 							var checkBut = $("<button>READY CHECK - " + queue.getAttribute("readyCheckSecsRemaining") + " s</button>");
@@ -892,44 +888,34 @@ var GempLotrHallUI = Class.extend({
 					else if (type === "table_draft") {
 						type = "Table Draft";
 					}
+					else if (type === "constructed") {
+						type = "Constructed";
+					}
 
 					var rowstr = "<tr class='queue" + id + "'><td>" + queue.getAttribute("format") + "</td>";
+					var collectionTd = "<td>" + queue.getAttribute("collection") + "</td>";
+					var queueNameTd = "<td>" + queue.getAttribute("queue") + "</td>";
 					var startTd = "<td>" + queue.getAttribute("start") + "</td>";
 					var systemTd = "<td>" + queue.getAttribute("system") + "</td>";
-					var playersTd = "<td><div class='prizeHint' title='Queued Players' value='" + queue.getAttribute("playerList") + "'>" + queue.getAttribute("playerCount") + "</div></td>";
 					var costPrizesTds = "<td align='right'>" + formatPrice(queue.getAttribute("cost")) + "</td><td>" + queue.getAttribute("prizes") + "</td>";
-					if (isWC) { // assumes that wc queue is always constructed
-						rowstr += "<td>" + queue.getAttribute("queue") + "</td>" +
-						startTd +
-						systemTd +
-						playersTd +
-						"</tr>";
-					} else if (type.includes("Sealed") || type.includes("Draft")) {
-						// No prizes and cost displayed for limited games
-						rowstr += "<td>" + type + "</td>";
-						rowstr += "<td><div";
-						if (type.includes("Table") && queue.hasAttribute("draftCode")) {
-							rowstr += " class='draftFormatInfo' draftCode='"+ queue.getAttribute("draftCode") + "'";
-						}
-						rowstr += ">" + queue.getAttribute("queue") + "</div></td>" +
-						startTd +
-						systemTd +
-						playersTd +
-						costPrizesTds +
-						"</tr>";
+					if (type.includes("Sealed") || type.includes("Draft")) {
+						collectionTd = "<td>" + type + "</td>";
 
-					} else {
-						rowstr += "<td>" + queue.getAttribute("collection") + "</td>" +
-						"<td>" + queue.getAttribute("queue") + "</td>" +
+						queueNameTd = "<td><div";
+						if (type.includes("Table") && queue.hasAttribute("draftCode")) {
+							queueNameTd += " class='draftFormatInfo' draftCode='"+ queue.getAttribute("draftCode") + "'";
+						}
+						queueNameTd += ">" + queue.getAttribute("queue") + "</div></td>";
+
+					}
+					rowstr += collectionTd +
+						queueNameTd +
 						startTd +
 						systemTd +
-						playersTd +
 						costPrizesTds +
 						"</tr>";
-					}
 						
 					var row = $(rowstr);
-					row.append(actionsField);
 
 					// Row for tournament queue waiting table
 					var tablesRow = $("<tr class='table" + id + "'></tr>");
@@ -948,28 +934,33 @@ var GempLotrHallUI = Class.extend({
 					tablesRow.append(htmlTd);
 					tablesRow.append("<td>" + queue.getAttribute("start") + "</td>");
 					tablesRow.append("<td>" + queue.getAttribute("playerList") + "</td>");
-					var actionsFieldClone = actionsField.clone(true);
-					tablesRow.append(actionsFieldClone);
-					if (joined == "true")
+					tablesRow.append(actionsField);
+					if (joined == "true") {
 						tablesRow.addClass("played");
+					} else if (isWC) {
+						tablesRow.addClass("wc-events");
+					}
 
 					if (action == "add") {
 						if(isWC) {
 							$("table.wc-queues", this.tablesDiv)
 							.append(row);
-						} else {
-							$("table.queues", this.tablesDiv)
+						} else if (isRecurring) {
+							$("table.recurringQueues", this.tablesDiv)
+							.append(row);
+						} else if (isScheduled) {
+							$("table.scheduledQueues", this.tablesDiv)
 							.append(row);
 						}
-						// Display queues with waiting players also as waiting tables
-						if (queue.getAttribute("playerCount") != 0 || isWC) {
+						// Display queues in waiting tables section
+						if (displayInWaitingTables) {
 							$("table.waitingTables", this.tablesDiv)
 								.append(tablesRow);
 						}
 					} else if (action == "update") {
 						$(".queue" + id, this.tablesDiv).replaceWith(row);
 						// Display queues with waiting players also as waiting tables
-						if (queue.getAttribute("playerCount") != 0) {
+						if (displayInWaitingTables) {
 							var existingRow = $(".table" + id, this.tablesDiv);
 							if (existingRow.length > 0) {
 								// If the row exists, replace it
@@ -978,7 +969,7 @@ var GempLotrHallUI = Class.extend({
 								// If the row does not exist, append it
 								$("table.waitingTables", this.tablesDiv).append(tablesRow);
 							}
-						} else if (queue.getAttribute("playerCount") == 0) {
+						} else {
 							// Remove tournaments displayed as tables
 							$(".table" + id, this.tablesDiv).remove();
 						}
@@ -987,8 +978,8 @@ var GempLotrHallUI = Class.extend({
 					this.animateRowUpdate(".queue" + id);
 					
 				} else if (action == "remove") {
+					// Remove from both the Waiting Tables Section and Queue Sections
 					$(".queue" + id, this.tablesDiv).remove();
-					// Remove tournaments displayed as tables
 					$(".table" + id, this.tablesDiv).remove();
 				}
 			}
@@ -998,6 +989,13 @@ var GempLotrHallUI = Class.extend({
 				$('#wcQueuesContent').hide();
 			} else {
 				$('#wcQueuesHeader').show();
+			}
+
+			if($('.scheduledQueues tr').length <= 1) {
+				$('#scheduledQueuesHeader').hide();
+				$('#scheduledQueuesContent').hide();
+			} else {
+				$('#scheduledQueuesHeader').show();
 			}
 
 			var tournaments = root.getElementsByTagName("tournament");
@@ -1125,28 +1123,24 @@ var GempLotrHallUI = Class.extend({
 						}
 					}
 
+					// Tournament for for tournament table (not in Playing Tables Section)
 					var rowstr = "";
-					
-					if(isWC) {
-						rowstr += "<tr class='tournament" + id + "'><td>" + tournament.getAttribute("format") + "</td>";
-					} else {
-						rowstr += "<tr class='tournament" + id + "'><td>" + tournament.getAttribute("format") + "</td>";
-						if(type === "sealed") {
-							rowstr += "<td>Sealed</td>";
-						}
-						else if (type === "solodraft") {
-							rowstr += "<td>Solo Draft</td>";
+					rowstr += "<tr class='tournament" + id + "'><td>" + tournament.getAttribute("format") + "</td>";
+					if(type === "sealed") {
+						rowstr += "<td>Sealed</td>";
+					}
+					else if (type === "solodraft") {
+						rowstr += "<td>Solo Draft</td>";
 
-						}
-						else if (type === "table_solodraft") {
-							rowstr += "<td>Solo Table Draft</td>";
-						}
-						else if (type === "table_draft") {
-							rowstr += "<td>Table Draft</td>";
-						}
-						else {
-							rowstr += "<td>" + tournament.getAttribute("collection") + "</td>";
-						}
+					}
+					else if (type === "table_solodraft") {
+						rowstr += "<td>Solo Table Draft</td>";
+					}
+					else if (type === "table_draft") {
+						rowstr += "<td>Table Draft</td>";
+					}
+					else {
+						rowstr += "<td>" + tournament.getAttribute("collection") + "</td>";
 					}
 					rowstr += "<td>" + tournament.getAttribute("name") + "</td>" +
 						"<td>" + tournament.getAttribute("system") + "</td>";
@@ -1157,9 +1151,7 @@ var GempLotrHallUI = Class.extend({
 					}
 					rowstr += "<td>" + tournament.getAttribute("round") + "</td>" +
 						"<td><div class='prizeHint' title='Competing Players' value='" + tournament.getAttribute("playerList") + "<br><br>* = abandoned'>" + tournament.getAttribute("playerCount") + "</div></td></tr>";
-
 					var row = $(rowstr);
-					row.append(actionsField);
 
 					// Row for tournament playing table
 					var displayType = type;
@@ -1175,21 +1167,29 @@ var GempLotrHallUI = Class.extend({
 					else if (type === "table_draft") {
 						displayType = "Table Draft";
 					}
+					else if (type === "constructed") {
+						displayType = "Constructed";
+					}
 					var tablesRow = $("<tr class='table" + id + "'></tr>");
 					tablesRow.append("<td>" + tournament.getAttribute("format") + "</td>");
-					tablesRow.append("<td> Tournament - " + displayType + " - " + tournament.getAttribute("name") + "</td>");
+					tablesRow.append("<td>" + tournament.getAttribute("system") + " Tournament - " + displayType + " - " + tournament.getAttribute("name") + "</td>");
 					if (tournament.hasAttribute("timeRemaining")) {
 						tablesRow.append("<td>" + tournament.getAttribute("stage") + " - " + tournament.getAttribute("timeRemaining") + "</td>");
+					} else if (tournament.getAttribute("stage") === "Playing Games") {
+						tablesRow.append("<td>" + tournament.getAttribute("stage") + " - Round " + tournament.getAttribute("round") + "</td>");
 					} else {
 						tablesRow.append("<td>" + tournament.getAttribute("stage") + "</td>");
 					}
 					tablesRow.append("<td>" + tournament.getAttribute("playerList") + "</td>");
-					var actionsFieldClone = actionsField.clone(true);
-					tablesRow.append(actionsFieldClone);
-					if (joined == "true")
+					tablesRow.append(actionsField);
+					if (joined == "true") {
 						tablesRow.addClass("played"); // red highlight
+					} else if (isWC) {
+						tablesRow.addClass("wc-events"); // yellow highlight
+					}
 
 					if (action == "add") {
+						// Right now the only tournament section is for WC events
 						if (isWC) {
 							$("table.wc-events", this.tablesDiv)
 							.append(row);
@@ -1213,9 +1213,10 @@ var GempLotrHallUI = Class.extend({
 						}
 
 					} else if (action == "update") {
+						// Update row in tournaments sections
 						$(".tournament" + id, this.tablesDiv).replaceWith(row);
 
-						// Display tournaments also as playing tables
+						// Update row in playing tables section
 						var existingRow = $(".table" + id, this.tablesDiv);
 						if (existingRow.length > 0) {
 							// If the row exists, replace it
@@ -1228,8 +1229,8 @@ var GempLotrHallUI = Class.extend({
 
 					this.animateRowUpdate(".tournament" + id);
 				} else if (action == "remove") {
+					// Remove tournament both from playing tables section and tournament sections
 					$(".tournament" + id, this.tablesDiv).remove();
-					// Remove tournaments displayed as tables
 					$(".table" + id, this.tablesDiv).remove();
 				}
 			}
@@ -1426,7 +1427,8 @@ var GempLotrHallUI = Class.extend({
 				}
 			}
 
-			$(".count", $(".eventHeader.queues")).html("(" + ($("tr", $("table.queues")).length - 1) + ")");
+			$(".count", $(".eventHeader.recurringQueues")).html("(" + ($("tr", $("table.recurringQueues")).length - 1) + ")");
+			$(".count", $(".eventHeader.scheduledQueues")).html("(" + ($("tr", $("table.scheduledQueues")).length - 1) + ")");
 			$(".count", $(".eventHeader.waitingTables")).html("(" + ($("tr", $("table.waitingTables")).length - 1) + ")");
 			$(".count", $(".eventHeader.playingTables")).html("(" + ($("tr", $("table.playingTables")).length - 1) + ")");
 			$(".count", $(".eventHeader.finishedTables")).html("(" + ($("tr", $("table.finishedTables")).length - 1) + ")");

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -272,6 +272,22 @@ var GempLotrHallUI = Class.extend({
                 $select.append($option);
             }
 
+			// Draft info link
+            const $draftInfoRow = $("<div>").addClass("formRow");
+            const $draftInfoLabel = $("<label>").text("Draft Format Info:");
+            const $draftInfoLink = $("<label>").addClass("italic").text("Select format first");
+            if (gameType === "table_draft") {
+                $select.on("change", function () {
+					// Create and append new info row
+					$draftInfoLink
+						.removeClass("italic")
+						.addClass("draftFormatInfo")
+						.attr("draftCode", $("#formatSelect").val())
+						.text($(this).find("option:selected").text());
+            	});
+            }
+            $draftInfoRow.append($draftInfoLabel, $draftInfoLink);
+
             // Number of players
             const $playersRow = $("<div>").addClass("formRow");
             const $playersLabel = $("<label>").attr("for", "numPlayers").text("Number of players:");
@@ -356,10 +372,11 @@ var GempLotrHallUI = Class.extend({
             $readyCheckSelect.val("90");
 
             // Append to form
-            $fields.append(
-                $("<div>").append($formatRow),
-                $("<div>").append($playersRow)
-            );
+            $fields.append($("<div>").append($formatRow));
+            if (gameType === "table_draft") {
+            	$fields.append($("<div>").append($draftInfoRow));
+            }
+            $fields.append($("<div>").append($playersRow));
 
             $advanced.append($("<div>").append($pairingRow));
             if (gameType !== "constructed") {

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -314,8 +314,12 @@ var GempLotrHallUI = Class.extend({
             const $durationRow = $("<div>").addClass("formRow");
             const $durationLabel = $("<label>").attr("for", "deckDuration").text("Deck-building duration (minutes, minimum 5):");
             const $durationInput = $("<input>")
-                .attr({ type: "number", id: "deckDuration", name: "deckDuration", min: 5 })
-                .val(15);
+                .attr({ type: "number", id: "deckDuration", name: "deckDuration", min: 5 });
+            if (gameType === "table_draft") {
+                $durationInput.val("15");
+            } else {
+                $durationInput.val("30");
+            }
             $durationRow.append($durationLabel, $durationInput);
 
             // Competitive

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -920,11 +920,12 @@ var GempLotrHallUI = Class.extend({
 					// Row for tournament queue waiting table
 					var tablesRow = $("<tr class='table" + id + "'></tr>");
 					tablesRow.append("<td>" + queue.getAttribute("format") + "</td>");
-					let htmlTd = "<td> ";
+					let htmlTd = "<td>";
 					if (isWC) {
 						htmlTd += "WC";
 					} else {
-						htmlTd += "Tournament"
+						// For system, ignore all after ',' (min players)
+						htmlTd += queue.getAttribute("system").split(',')[0] + " Tournament";
 					}
 					htmlTd += " - " + type + " - <div style='display:inline'"
 					if (type.includes("Table") && queue.hasAttribute("draftCode")) {

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -915,6 +915,7 @@ var GempLotrHallUI = Class.extend({
 						startTd +
 						systemTd +
 						playersTd +
+						costPrizesTds +
 						"</tr>";
 
 					} else {

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -185,8 +185,10 @@ var GempLotrHallUI = Class.extend({
             const playerCount = parseInt($("#numPlayers").val(), 10);
             const deckDuration = parseInt($("#deckDuration").val(), 10);
             const draftTimer = $("#draftTimer").val();
+            const competitive = $("#competitiveSelect").val();
+            const startableEarly = $("#startableEarlySelect").val();
 
-            const validPlayerCount = Number.isInteger(playerCount) && playerCount >= 2;
+            const validPlayerCount = Number.isInteger(playerCount) && playerCount >= 1;
             const validDeckDuration = Number.isInteger(deckDuration) && deckDuration >= 5;
             const draftValid = gameType !== "table_draft" || draftTimer;
 
@@ -196,6 +198,8 @@ var GempLotrHallUI = Class.extend({
                 pairingType &&
                 validPlayerCount &&
                 validDeckDuration &&
+                competitive &&
+                startableEarly &&
                 draftValid;
 
             $("#createTournamentButton").prop("disabled", !allValid);
@@ -249,7 +253,7 @@ var GempLotrHallUI = Class.extend({
             // Number of players
             const $playersLabel = $("<label>").attr("for", "numPlayers").text("Number of players:");
             const $playersInput = $("<input>")
-                .attr({ type: "number", id: "numPlayers", name: "numPlayers", min: 2 })
+                .attr({ type: "number", id: "numPlayers", name: "numPlayers", min: 1 })
                 .val(4);
 
             // Pairing type
@@ -259,6 +263,12 @@ var GempLotrHallUI = Class.extend({
                 .append($("<option>").val("SWISS").text("Swiss"))
                 .append($("<option>").val("SINGLE_ELIMINATION").text("Single elimination"));
 
+            // Deck-building duration
+            const $durationLabel = $("<label>").attr("for", "deckDuration").text("Deck-building duration (minutes, minimum 5):");
+            const $durationInput = $("<input>")
+                .attr({ type: "number", id: "deckDuration", name: "deckDuration", min: 5 })
+                .val(15);
+
             // Competitive
             const $competitiveLabel = $("<label>").attr("for", "competitiveSelect").text("Competitive:");
             const $competitiveSelect = $("<select>")
@@ -266,11 +276,12 @@ var GempLotrHallUI = Class.extend({
                 .append($("<option>").val("false").text("Games can be spectated"))
                 .append($("<option>").val("true").text("No spectate; hidden names in queue"));
 
-            // Deck-building duration
-            const $durationLabel = $("<label>").attr("for", "deckDuration").text("Deck-building duration (minutes, minimum 5):");
-            const $durationInput = $("<input>")
-                .attr({ type: "number", id: "deckDuration", name: "deckDuration", min: 5 })
-                .val(15);
+            // Early start
+            const $earlyStartLabel = $("<label>").attr("for", "startableEarlySelect").text("Early start:");
+            const $earlyStartSelect = $("<select>")
+                .attr({ id: "startableEarlySelect", name: "startableEarly" })
+                .append($("<option>").val("true").text("Can be started with less players"))
+                .append($("<option>").val("false").text("Starts only with all player slots filled"));
 
             // Append to form
             $fields.append(
@@ -305,7 +316,9 @@ var GempLotrHallUI = Class.extend({
                 $("<div>").append($durationLabel),
                 $("<div>").append($durationInput),
                 $("<div>").append($competitiveLabel),
-                $("<div>").append($competitiveSelect)
+                $("<div>").append($competitiveSelect),
+                $("<div>").append($earlyStartLabel),
+                $("<div>").append($earlyStartSelect)
             );
 
             // Add validating listeners
@@ -313,6 +326,8 @@ var GempLotrHallUI = Class.extend({
             $playersInput.on("input", validateTournamentForm);
             $pairingSelect.on("change", validateTournamentForm);
             $durationInput.on("input", validateTournamentForm);
+            $competitiveSelect.on("change", validateTournamentForm);
+            $earlyStartSelect.on("change", validateTournamentForm);
             if (gameType === "table_draft") {
                 $timerSelect.on("change", validateTournamentForm);
             }
@@ -350,13 +365,12 @@ var GempLotrHallUI = Class.extend({
             // Draft timer only applies to table draft
             const tableDraftTimer = type === "table_draft" ? $("#draftTimer").val() : null;
 
-            // Pairing
             const playoff = $("#pairingType").val();
-
             const competitive = $("#competitiveSelect").val();
+            const startableEarly = $("#startableEarlySelect").val();
 
 
-            // Deck building duration (number input)
+            // Number input
             const deckbuildingDuration = parseInt($("#deckDuration").val(), 10) || 15;
             const maxPlayers = parseInt($("#numPlayers").val(), 10) || 4;
 
@@ -371,6 +385,7 @@ var GempLotrHallUI = Class.extend({
                 playoff,
                 deckbuildingDuration,
                 competitive,
+                startableEarly,
                 function(json) {
                     // Success callback — handle your response here
                     console.log("Tournament created successfully:", json);

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -118,7 +118,7 @@ var GempLotrHallUI = Class.extend({
 
 		var hallSettingsStr = $.cookie("hallSettings");
 		if (hallSettingsStr == null)
-			hallSettingsStr = "1|1|0|0|0|0|0|0|0";
+			hallSettingsStr = "1|1|0|0|0|0|0";
 		var hallSettings = hallSettingsStr.split("|");
 
 		this.initTable(hallSettings[0] == "1", "waitingTablesHeader", "waitingTablesContent");
@@ -127,9 +127,7 @@ var GempLotrHallUI = Class.extend({
 		this.initTable(hallSettings[3] == "1", "wcQueuesHeader", "wcQueuesContent");
 		this.initTable(hallSettings[4] == "1", "wcEventsHeader", "wcEventsContent");
 		this.initTable(hallSettings[5] == "1", "tournamentQueuesHeader", "tournamentQueuesContent");
-		this.initTable(hallSettings[6] == "1", "draftQueuesHeader", "draftQueuesContent");
-		this.initTable(hallSettings[7] == "1", "sealedQueuesHeader", "sealedQueuesContent");
-		this.initTable(hallSettings[8] == "1", "activeTournamentsHeader", "activeTournamentsContent");
+		this.initTable(hallSettings[6] == "1", "limitedGamesHeader", "limitedGamesContent");
 		
 		$('#wcQueuesHeader').hide();
 		$('#wcQueuesContent').hide();
@@ -942,12 +940,6 @@ var GempLotrHallUI = Class.extend({
 						if(isWC) {
 							$("table.wc-queues", this.tablesDiv)
 							.append(row);
-						} else if (type.includes("Sealed")) {
-							$("table.sealedQueues", this.tablesDiv)
-							.append(row);
-						} else if (type.includes("Draft")) {
-							$("table.draftQueues", this.tablesDiv)
-							.append(row);
 						} else {
 							$("table.queues", this.tablesDiv)
 							.append(row);
@@ -1184,9 +1176,6 @@ var GempLotrHallUI = Class.extend({
 						if (isWC) {
 							$("table.wc-events", this.tablesDiv)
 							.append(row);
-						} else {
-							$("table.tournaments", this.tablesDiv)
-							.append(row);
 						}
 						// Display running tournaments also as playing tables
 						$("table.playingTables", this.tablesDiv)
@@ -1421,12 +1410,9 @@ var GempLotrHallUI = Class.extend({
 			}
 
 			$(".count", $(".eventHeader.queues")).html("(" + ($("tr", $("table.queues")).length - 1) + ")");
-			$(".count", $(".eventHeader.tournaments")).html("(" + ($("tr", $("table.tournaments")).length - 1) + ")");
 			$(".count", $(".eventHeader.waitingTables")).html("(" + ($("tr", $("table.waitingTables")).length - 1) + ")");
 			$(".count", $(".eventHeader.playingTables")).html("(" + ($("tr", $("table.playingTables")).length - 1) + ")");
 			$(".count", $(".eventHeader.finishedTables")).html("(" + ($("tr", $("table.finishedTables")).length - 1) + ")");
-			$(".count", $(".eventHeader.draftQueues")).html("(" + ($("tr", $("table.draftQueues")).length - 1) + ")");
-			$(".count", $(".eventHeader.sealedQueues")).html("(" + ($("tr", $("table.sealedQueues")).length - 1) + ")");
 
 			$(".count", $(".eventHeader.wc-queues")).html("(" + ($("tr", $("table.wc-queues")).length - 1) + ")");
 			$(".count", $(".eventHeader.wc-events")).html("(" + ($("tr", $("table.wc-events")).length - 1) + ")");

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -641,27 +641,28 @@ var GempLotrHallUI = Class.extend({
     },
 	
 	initTable: function(displayed, headerID, tableID) {
-		var header = $("#" + headerID);
+		const header = $("#" + headerID);
+		const content = $("#" + tableID);
+		const that = this;
 
-		var content = $("#" + tableID);
+		// Inject triangle span if not already present
+		if (header.find(".disclosureTriangle").length === 0) {
+			header.prepend("<span class='disclosureTriangle'></span>");
+		}
 
-		var that = this;
-		var toggle = function() {
-			if (content.hasClass("hidden"))
-				content.removeClass("hidden");
-			else
-				content.addClass("hidden");
-			content.toggle("blind", {}, 200);
+		const toggle = function () {
+			content.toggleClass("hidden").toggle("blind", {}, 200);
+			header.toggleClass("expanded");
 			that.updateHallSettings();
 		};
-		
-		header.click(toggle);
+
+		header.off("click").on("click", toggle);
 
 		if (displayed) {
 			content.show();
+			header.addClass("expanded");
 		} else {
-			content.addClass("hidden");
-			content.hide();
+			content.addClass("hidden").hide();
 		}
 	},
 

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -58,17 +58,17 @@ var GempLotrHallUI = Class.extend({
 
 		this.chat = chat;
 		this.chat.tournamentCallback = function(from, message) {
-				var thisName = that.userInfo.name
+			var thisName = that.userInfo.name
 			if (from == "TournamentSystem" && that.inTournament) {
 				that.showDialog("Tournament Update", message, 320);
 			} else if (from.startsWith("TournamentSystemTo:")) {
-								// Extract and split the user list
-								let users = from.split(":")[1].split(";");
+				// Extract and split the user list
+				let users = from.split(":")[1].split(";");
 
-								// Check if thisName is in the list
-								if (users.includes(thisName)) {
-						that.showDialog("Tournament Update", message, 320);
-								}
+				// Check if thisName is in the list
+				if (users.includes(thisName)) {
+					that.showDialog("Tournament Update", message, 320);
+				}
 			}
 		};
 
@@ -826,57 +826,57 @@ var GempLotrHallUI = Class.extend({
 							})(queue));
 						actionsField.append(but);
 
-												if (queue.getAttribute("startable") == "true") {
-														var startBut = $("<button>Start Now</button>");
-														$(startBut).button().click((
-																function(queueInfo) {
-																		return function() {
-																				var queueId = queueInfo.getAttribute("id");
-																				that.comm.startQueue(queueId, function (xml) {
-																						var result = that.processResponse(xml);
-																				});
-																		}
-																})(queue));
-								actionsField.append(startBut);
-												}
+						if (queue.getAttribute("startable") == "true") {
+							var startBut = $("<button>Start Now</button>");
+							$(startBut).button().click((
+								function(queueInfo) {
+									return function() {
+										var queueId = queueInfo.getAttribute("id");
+										that.comm.startQueue(queueId, function (xml) {
+											var result = that.processResponse(xml);
+										});
+									}
+								})(queue));
+							actionsField.append(startBut);
+						}
 
-												if (+queue.getAttribute("readyCheckSecsRemaining") > -1) {
-														if ($("button:contains('READY CHECK')").length === 0 && queue.getAttribute("confirmedReadyCheck") == "false") {
-																that.showDialog("Ready Check", "Ready Check started for the <b>" + queue.getAttribute("queue")
-																 + "</b> tournament.<br><br>To confirm you are present, click the Ready Check button within next "
-																	+ queue.getAttribute("readyCheckSecsRemaining") + " seconds.", 230);
-														}
-														var checkBut = $("<button>READY CHECK - " + queue.getAttribute("readyCheckSecsRemaining") + " s</button>");
-														$(checkBut).button().click((
-																function(queueInfo) {
-																		return function() {
-																				var queueId = queueInfo.getAttribute("id");
-																				that.comm.confirmReadyCheckQueue(queueId, function (xml) {
-																						var result = that.processResponse(xml);
-																				});
-																		}
-																})(queue));
-								actionsField.append(checkBut);
-								if (queue.getAttribute("confirmedReadyCheck") == "true") {
-																$(checkBut).prop("disabled", true).text("Waiting for others - " + queue.getAttribute("readyCheckSecsRemaining") + " s");
-								}
-												}
+						if (+queue.getAttribute("readyCheckSecsRemaining") > -1) {
+							if ($("button:contains('READY CHECK')").length === 0 && queue.getAttribute("confirmedReadyCheck") == "false") {
+								that.showDialog("Ready Check", "Ready Check started for the <b>" + queue.getAttribute("queue")
+									+ "</b> tournament.<br><br>To confirm you are present, click the Ready Check button within next "
+									+ queue.getAttribute("readyCheckSecsRemaining") + " seconds.", 230);
+							}
+							var checkBut = $("<button>READY CHECK - " + queue.getAttribute("readyCheckSecsRemaining") + " s</button>");
+							$(checkBut).button().click((
+								function(queueInfo) {
+									return function() {
+										var queueId = queueInfo.getAttribute("id");
+										that.comm.confirmReadyCheckQueue(queueId, function (xml) {
+											var result = that.processResponse(xml);
+										});
+									}
+								})(queue));
+							actionsField.append(checkBut);
+							if (queue.getAttribute("confirmedReadyCheck") == "true") {
+								$(checkBut).prop("disabled", true).text("Waiting for others - " + queue.getAttribute("readyCheckSecsRemaining") + " s");
+							}
+						}
 					}
-										var type = queue.getAttribute("type");
-										if(type !== null)
-												type = type.toLowerCase();
-										if(type === "sealed") {
-												type = "Sealed";
-										}
-										else if (type === "solodraft") {
-												type = "Solo Draft";
-										}
-										else if (type === "table_solodraft") {
-												type = "Solo Table Draft";
-										}
-										else if (type === "table_draft") {
-												type = "Table Draft";
-										}
+					var type = queue.getAttribute("type");
+					if(type !== null)
+						type = type.toLowerCase();
+					if(type === "sealed") {
+						type = "Sealed";
+					}
+					else if (type === "solodraft") {
+						type = "Solo Draft";
+					}
+					else if (type === "table_solodraft") {
+						type = "Solo Table Draft";
+					}
+					else if (type === "table_draft") {
+						type = "Table Draft";
+					}
 
 					var rowstr = "<tr class='queue" + id + "'><td>" + queue.getAttribute("format") + "</td>";
 					var startTd = "<td>" + queue.getAttribute("start") + "</td>";
@@ -891,10 +891,10 @@ var GempLotrHallUI = Class.extend({
 						"</tr>";
 					} else if (type.includes("Sealed") || type.includes("Draft")) {
 						// No prizes and cost displayed for limited games
-							rowstr += "<td>" + type + "</td>";
+						rowstr += "<td>" + type + "</td>";
 						rowstr += "<td><div";
 						if (type.includes("Table") && queue.hasAttribute("draftCode")) {
-								rowstr += " class='draftFormatInfo' draftCode='"+ queue.getAttribute("draftCode") + "'";
+							rowstr += " class='draftFormatInfo' draftCode='"+ queue.getAttribute("draftCode") + "'";
 						}
 						rowstr += ">" + queue.getAttribute("queue") + "</div></td>" +
 						startTd +
@@ -916,25 +916,25 @@ var GempLotrHallUI = Class.extend({
 					row.append(actionsField);
 
 					// Row for tournament queue waiting table
-										var tablesRow = $("<tr class='table" + id + "'></tr>");
-										tablesRow.append("<td>" + queue.getAttribute("format") + "</td>");
-										let htmlTd = "<td> ";
-										if (isWC) {
-												htmlTd += "WC";
-										} else {
-												htmlTd += "Tournament"
-										}
-										htmlTd += " - " + type + " - <div style='display:inline'"
-										if (type.includes("Table") && queue.hasAttribute("draftCode")) {
-											 htmlTd += " class='draftFormatInfo' draftCode='"+ queue.getAttribute("draftCode") + "'";
-										}
-										htmlTd += ">" + queue.getAttribute("queue") + "</div></td>";
-										tablesRow.append(htmlTd);
-										tablesRow.append("<td>" + queue.getAttribute("start") + "</td>");
-										tablesRow.append("<td>" + queue.getAttribute("playerList") + "</td>");
-										var actionsFieldClone = actionsField.clone(true);
-										tablesRow.append(actionsFieldClone);
-										if (joined == "true")
+					var tablesRow = $("<tr class='table" + id + "'></tr>");
+					tablesRow.append("<td>" + queue.getAttribute("format") + "</td>");
+					let htmlTd = "<td> ";
+					if (isWC) {
+						htmlTd += "WC";
+					} else {
+						htmlTd += "Tournament"
+					}
+					htmlTd += " - " + type + " - <div style='display:inline'"
+					if (type.includes("Table") && queue.hasAttribute("draftCode")) {
+						htmlTd += " class='draftFormatInfo' draftCode='"+ queue.getAttribute("draftCode") + "'";
+					}
+					htmlTd += ">" + queue.getAttribute("queue") + "</div></td>";
+					tablesRow.append(htmlTd);
+					tablesRow.append("<td>" + queue.getAttribute("start") + "</td>");
+					tablesRow.append("<td>" + queue.getAttribute("playerList") + "</td>");
+					var actionsFieldClone = actionsField.clone(true);
+					tablesRow.append(actionsFieldClone);
+					if (joined == "true")
 						tablesRow.addClass("played");
 
 					if (action == "add") {
@@ -942,45 +942,44 @@ var GempLotrHallUI = Class.extend({
 							$("table.wc-queues", this.tablesDiv)
 							.append(row);
 						} else if (type.includes("Sealed")) {
-														$("table.sealedQueues", this.tablesDiv)
-														.append(row);
-												} else if (type.includes("Draft")) {
+							$("table.sealedQueues", this.tablesDiv)
+							.append(row);
+						} else if (type.includes("Draft")) {
 							$("table.draftQueues", this.tablesDiv)
 							.append(row);
 						} else {
 							$("table.queues", this.tablesDiv)
 							.append(row);
 						}
-												// Display queues with waiting players also as waiting tables
-												if (queue.getAttribute("playerCount") != 0 || isWC) {
-														$("table.waitingTables", this.tablesDiv)
-																.append(tablesRow);
-												}
+						// Display queues with waiting players also as waiting tables
+						if (queue.getAttribute("playerCount") != 0 || isWC) {
+							$("table.waitingTables", this.tablesDiv)
+								.append(tablesRow);
+						}
 					} else if (action == "update") {
 						$(".queue" + id, this.tablesDiv).replaceWith(row);
-												// Display queues with waiting players also as waiting tables
-												if (queue.getAttribute("playerCount") != 0) {
-														var existingRow = $(".table" + id, this.tablesDiv);
-														if (existingRow.length > 0) {
-																// If the row exists, replace it
-																existingRow.replaceWith(tablesRow);
-														} else {
-																// If the row does not exist, append it
-																$("table.waitingTables", this.tablesDiv).append(tablesRow);
-														}
-												} else if (queue.getAttribute("playerCount") == 0) {
-														// Remove tournaments displayed as tables
-														$(".table" + id, this.tablesDiv).remove();
-												}
+						// Display queues with waiting players also as waiting tables
+						if (queue.getAttribute("playerCount") != 0) {
+							var existingRow = $(".table" + id, this.tablesDiv);
+							if (existingRow.length > 0) {
+								// If the row exists, replace it
+								existingRow.replaceWith(tablesRow);
+							} else {
+								// If the row does not exist, append it
+								$("table.waitingTables", this.tablesDiv).append(tablesRow);
+							}
+						} else if (queue.getAttribute("playerCount") == 0) {
+							// Remove tournaments displayed as tables
+							$(".table" + id, this.tablesDiv).remove();
+						}
 					}
 
 					this.animateRowUpdate(".queue" + id);
 					
 				} else if (action == "remove") {
-										$(".queue" + id, this.tablesDiv).remove();
-										// Remove tournaments displayed as tables
-										$(".table" + id, this.tablesDiv).remove();
-					
+					$(".queue" + id, this.tablesDiv).remove();
+					// Remove tournaments displayed as tables
+					$(".table" + id, this.tablesDiv).remove();
 				}
 			}
 			
@@ -1013,55 +1012,52 @@ var GempLotrHallUI = Class.extend({
 						that.inTournament = true;
 						debugger;
 						if(type === "solodraft" && (stage === "deck-building" || stage === "registering decks" || stage === "awaiting kickoff")) {
-								var but = $("<button>Go to Draft</button>");
-								$(but).button().click((
-									function(tourneyInfo) {
-										var tourneyId = tournament.getAttribute("id");
-
-																				return function() {
-																						var win = window.open("/gemp-lotr/soloDraft.html?eventId=" + tourneyId, '_blank');
-																						if (win) {
-																								//Browser has allowed it to be opened
-																						win.focus();
-																						}
-																				}
+							var but = $("<button>Go to Draft</button>");
+							$(but).button().click((
+								function(tourneyInfo) {
+									var tourneyId = tournament.getAttribute("id");
+									return function() {
+										var win = window.open("/gemp-lotr/soloDraft.html?eventId=" + tourneyId, '_blank');
+										if (win) {
+											//Browser has allowed it to be opened
+											win.focus();
+										}
 									}
-									)(tournament));
-								actionsField.append(but);
+								}
+							)(tournament));
+							actionsField.append(but);
 						}
 						if(type === "table_solodraft" && (stage === "deck-building" || stage === "registering decks" || stage === "awaiting kickoff")) {
-								var but = $("<button>Go to Draft</button>");
-								$(but).button().click((
-									function(tourneyInfo) {
-										var tourneyId = tournament.getAttribute("id");
-
-																				return function() {
-																						var win = window.open("/gemp-lotr/tableDraft.html?eventId=" + tourneyId, '_blank');
-																						if (win) {
-																								//Browser has allowed it to be opened
-																						win.focus();
-																						}
-																				}
+							var but = $("<button>Go to Draft</button>");
+							$(but).button().click((
+								function(tourneyInfo) {
+									var tourneyId = tournament.getAttribute("id");
+									return function() {
+										var win = window.open("/gemp-lotr/tableDraft.html?eventId=" + tourneyId, '_blank');
+										if (win) {
+											//Browser has allowed it to be opened
+											win.focus();
+										}
 									}
-									)(tournament));
-								actionsField.append(but);
+								}
+							)(tournament));
+							actionsField.append(but);
 						}
 						if(type === "table_draft" && stage === "drafting") {
-								var but = $("<button>Go to Draft</button>");
-								$(but).button().click((
-									function(tourneyInfo) {
-										var tourneyId = tournament.getAttribute("id");
-
-																				return function() {
-																						var win = window.open("/gemp-lotr/tableDraft.html?eventId=" + tourneyId, '_blank');
-																						if (win) {
-																								//Browser has allowed it to be opened
-																						win.focus();
-																						}
-																				}
+							var but = $("<button>Go to Draft</button>");
+							$(but).button().click((
+								function(tourneyInfo) {
+									var tourneyId = tournament.getAttribute("id");
+									return function() {
+										var win = window.open("/gemp-lotr/tableDraft.html?eventId=" + tourneyId, '_blank');
+										if (win) {
+											//Browser has allowed it to be opened
+											win.focus();
+										}
 									}
-									)(tournament));
-								actionsField.append(but);
+								}
+							)(tournament));
+							actionsField.append(but);
 						}
 						if((type === "sealed" || type === "solodraft" || type === "table_solodraft" || type === "table_draft") && (stage === "deck-building" || stage === "registering decks" || stage === "awaiting kickoff" || stage === "paused between rounds")) {
 								var but = $("<button>Register Deck</button>");
@@ -1134,7 +1130,7 @@ var GempLotrHallUI = Class.extend({
 						}
 						else if (type === "table_solodraft") {
 							rowstr += "<td>Solo Table Draft</td>";
-							}
+						}
 						else if (type === "table_draft") {
 							rowstr += "<td>Table Draft</td>";
 						}
@@ -1143,44 +1139,43 @@ var GempLotrHallUI = Class.extend({
 						}
 					}
 					rowstr += "<td>" + tournament.getAttribute("name") + "</td>" +
-										"<td>" + tournament.getAttribute("system") + "</td>";
-										if (tournament.hasAttribute("timeRemaining")) {
-												rowstr += "<td>" + tournament.getAttribute("stage") + " - " + tournament.getAttribute("timeRemaining") + "</td>";
-										} else {
-												rowstr += "<td>" + tournament.getAttribute("stage") + "</td>";
-										}
-										rowstr += "<td>" + tournament.getAttribute("round") + "</td>" +
-										"<td><div class='prizeHint' title='Competing Players' value='" + tournament.getAttribute("playerList") + "<br><br>* = abandoned'>" + tournament.getAttribute("playerCount") + "</div></td></tr>";
+						"<td>" + tournament.getAttribute("system") + "</td>";
+					if (tournament.hasAttribute("timeRemaining")) {
+						rowstr += "<td>" + tournament.getAttribute("stage") + " - " + tournament.getAttribute("timeRemaining") + "</td>";
+					} else {
+						rowstr += "<td>" + tournament.getAttribute("stage") + "</td>";
+					}
+					rowstr += "<td>" + tournament.getAttribute("round") + "</td>" +
+						"<td><div class='prizeHint' title='Competing Players' value='" + tournament.getAttribute("playerList") + "<br><br>* = abandoned'>" + tournament.getAttribute("playerCount") + "</div></td></tr>";
 
 					var row = $(rowstr);
 					row.append(actionsField);
 
-
-										// Row for tournament playing table
-										var displayType = type;
-										if(type === "sealed") {
-												displayType = "Sealed";
-										}
-										else if (type === "solodraft") {
-												displayType = "Solo Draft";
-										}
-										else if (type === "table_solodraft") {
-												displayType = "Solo Table Draft";
-										}
-										else if (type === "table_draft") {
-												displayType = "Table Draft";
-										}
-										var tablesRow = $("<tr class='table" + id + "'></tr>");
-										tablesRow.append("<td>" + tournament.getAttribute("format") + "</td>");
-										tablesRow.append("<td> Tournament - " + displayType + " - " + tournament.getAttribute("name") + "</td>");
-										if (tournament.hasAttribute("timeRemaining")) {
-												tablesRow.append("<td>" + tournament.getAttribute("stage") + " - " + tournament.getAttribute("timeRemaining") + "</td>");
-										} else {
-												tablesRow.append("<td>" + tournament.getAttribute("stage") + "</td>");
-										}
-										tablesRow.append("<td>" + tournament.getAttribute("playerList") + "</td>");
-										var actionsFieldClone = actionsField.clone(true);
-										tablesRow.append(actionsFieldClone);
+					// Row for tournament playing table
+					var displayType = type;
+					if(type === "sealed") {
+						displayType = "Sealed";
+					}
+					else if (type === "solodraft") {
+						displayType = "Solo Draft";
+					}
+					else if (type === "table_solodraft") {
+						displayType = "Solo Table Draft";
+					}
+					else if (type === "table_draft") {
+						displayType = "Table Draft";
+					}
+					var tablesRow = $("<tr class='table" + id + "'></tr>");
+					tablesRow.append("<td>" + tournament.getAttribute("format") + "</td>");
+					tablesRow.append("<td> Tournament - " + displayType + " - " + tournament.getAttribute("name") + "</td>");
+					if (tournament.hasAttribute("timeRemaining")) {
+						tablesRow.append("<td>" + tournament.getAttribute("stage") + " - " + tournament.getAttribute("timeRemaining") + "</td>");
+					} else {
+						tablesRow.append("<td>" + tournament.getAttribute("stage") + "</td>");
+					}
+					tablesRow.append("<td>" + tournament.getAttribute("playerList") + "</td>");
+					var actionsFieldClone = actionsField.clone(true);
+					tablesRow.append(actionsFieldClone);
 					if (joined == "true")
 						tablesRow.addClass("played"); // red highlight
 
@@ -1192,43 +1187,43 @@ var GempLotrHallUI = Class.extend({
 							$("table.tournaments", this.tablesDiv)
 							.append(row);
 						}
-												// Display running tournaments also as playing tables
-												$("table.playingTables", this.tablesDiv)
-														.append(tablesRow)
+						// Display running tournaments also as playing tables
+						$("table.playingTables", this.tablesDiv)
+							.append(tablesRow)
 
-												if (joined == "true") {
-														// Open draft window
-														if ((type === "table_solodraft" && (stage === "deck-building" || stage === "registering decks" || stage === "awaiting kickoff"))
-														|| (type === "table_draft" && stage === "drafting")) {
-																var tourneyId = tournament.getAttribute("id");
-																window.open("/gemp-lotr/tableDraft.html?eventId=" + tourneyId, '_blank');
-																this.PlaySound("gamestart");
-														} else if (type === "solodraft" && (stage === "deck-building" || stage === "registering decks" || stage === "awaiting kickoff")) {
-																var tourneyId = tournament.getAttribute("id");
-																window.open("/gemp-lotr/soloDraft.html?eventId=" + tourneyId, '_blank');
-																this.PlaySound("gamestart");
-														}
-												}
+						if (joined == "true") {
+							// Open draft window
+							if ((type === "table_solodraft" && (stage === "deck-building" || stage === "registering decks" || stage === "awaiting kickoff"))
+							|| (type === "table_draft" && stage === "drafting")) {
+								var tourneyId = tournament.getAttribute("id");
+								window.open("/gemp-lotr/tableDraft.html?eventId=" + tourneyId, '_blank');
+								this.PlaySound("gamestart");
+							} else if (type === "solodraft" && (stage === "deck-building" || stage === "registering decks" || stage === "awaiting kickoff")) {
+								var tourneyId = tournament.getAttribute("id");
+								window.open("/gemp-lotr/soloDraft.html?eventId=" + tourneyId, '_blank');
+								this.PlaySound("gamestart");
+							}
+						}
 
 					} else if (action == "update") {
-												$(".tournament" + id, this.tablesDiv).replaceWith(row);
+						$(".tournament" + id, this.tablesDiv).replaceWith(row);
 
-												// Display tournaments also as playing tables
-												var existingRow = $(".table" + id, this.tablesDiv);
-												if (existingRow.length > 0) {
-														// If the row exists, replace it
-														existingRow.replaceWith(tablesRow);
-												} else {
-														// If the row does not exist, append it
-														$("table.playingTables", this.tablesDiv).append(tablesRow);
-												}
+						// Display tournaments also as playing tables
+						var existingRow = $(".table" + id, this.tablesDiv);
+						if (existingRow.length > 0) {
+							// If the row exists, replace it
+							existingRow.replaceWith(tablesRow);
+						} else {
+							// If the row does not exist, append it
+							$("table.playingTables", this.tablesDiv).append(tablesRow);
+						}
 					}
 
 					this.animateRowUpdate(".tournament" + id);
 				} else if (action == "remove") {
-										$(".tournament" + id, this.tablesDiv).remove();
-										// Remove tournaments displayed as tables
-										$(".table" + id, this.tablesDiv).remove();
+					$(".tournament" + id, this.tablesDiv).remove();
+					// Remove tournaments displayed as tables
+					$(".table" + id, this.tablesDiv).remove();
 				}
 			}
 			

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -443,56 +443,57 @@ var GempLotrHallUI = Class.extend({
 	},
 
 	createTournament: function() {
-	    const type = $("#gameTypeSelect").val();
-            // Depending on the type, pick the correct format code from the formatSelect dropdown
-            const formatCode = $("#formatSelect").val();
+		var that = this;
 
-            // Assign the format codes based on the selected game type
-            let sealedFormatCode = null;
-            let soloDraftFormatCode = null;
-            let tableDraftFormatCode = null;
+		const type = $("#gameTypeSelect").val();
+		// Depending on the type, pick the correct format code from the formatSelect dropdown
+		const formatCode = $("#formatSelect").val();
 
-            if (type === "sealed") {
-                sealedFormatCode = formatCode;
-            } else if (type === "solodraft") {
-                soloDraftFormatCode = formatCode;
-            } else if (type === "table_draft") {
-                tableDraftFormatCode = formatCode;
-            }
+		// Assign the format codes based on the selected game type
+		let sealedFormatCode = null;
+		let soloDraftFormatCode = null;
+		let tableDraftFormatCode = null;
 
-            // Draft timer only applies to table draft
-            const tableDraftTimer = type === "table_draft" ? $("#draftTimer").val() : null;
+		if (type === "sealed") {
+			sealedFormatCode = formatCode;
+		} else if (type === "solodraft") {
+			soloDraftFormatCode = formatCode;
+		} else if (type === "table_draft") {
+			tableDraftFormatCode = formatCode;
+		}
 
-            const playoff = $("#pairingType").val();
-            const competitive = $("#competitiveSelect").val();
-            const startableEarly = $("#startableEarlySelect").val();
-            const readyCheck = $("#readyCheckSelect").val();
+		// Draft timer only applies to table draft
+		const tableDraftTimer = type === "table_draft" ? $("#draftTimer").val() : null;
+
+		const playoff = $("#pairingType").val();
+		const competitive = $("#competitiveSelect").val();
+		const startableEarly = $("#startableEarlySelect").val();
+		const readyCheck = $("#readyCheckSelect").val();
 
 
-            // Number input
-            const deckbuildingDuration = parseInt($("#deckDuration").val(), 10) || 15;
-            const maxPlayers = parseInt($("#numPlayers").val(), 10) || 4;
+		// Number input
+		const deckbuildingDuration = parseInt($("#deckDuration").val(), 10) || 15;
+		const maxPlayers = parseInt($("#numPlayers").val(), 10) || 4;
 
-            // Call the communication layer with all gathered values
-            this.comm.createTournament(
-                type,
-                maxPlayers,
-                sealedFormatCode,
-                soloDraftFormatCode,
-                tableDraftFormatCode,
-                tableDraftTimer,
-                playoff,
-                deckbuildingDuration,
-                competitive,
-                startableEarly,
-                readyCheck,
-                function(json) {
-                    // Success callback — handle your response here
-                    console.log("Tournament created successfully:", json);
-                    // You can add preview or other logic here as needed
-                },
-                this.hallErrorMap()
-            );
+		// Call the communication layer with all gathered values
+		this.comm.createTournament(
+			type,
+			maxPlayers,
+			sealedFormatCode,
+			soloDraftFormatCode,
+			tableDraftFormatCode,
+			tableDraftTimer,
+			playoff,
+			deckbuildingDuration,
+			competitive,
+			startableEarly,
+			readyCheck,
+			function(json) {
+				// Success callback
+				that.showDialog("Tournament Update", "Tournament queue created successfully");
+			},
+			this.hallErrorMap()
+		);
     },
 	
 	initTable: function(displayed, headerID, tableID) {
@@ -1426,7 +1427,7 @@ var GempLotrHallUI = Class.extend({
 			$(".count", $(".eventHeader.finishedTables")).html("(" + ($("tr", $("table.finishedTables")).length - 1) + ")");
 			$(".count", $(".eventHeader.draftQueues")).html("(" + ($("tr", $("table.draftQueues")).length - 1) + ")");
 			$(".count", $(".eventHeader.sealedQueues")).html("(" + ($("tr", $("table.sealedQueues")).length - 1) + ")");
-			
+
 			$(".count", $(".eventHeader.wc-queues")).html("(" + ($("tr", $("table.wc-queues")).length - 1) + ")");
 			$(".count", $(".eventHeader.wc-events")).html("(" + ($("tr", $("table.wc-events")).length - 1) + ")");
 

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -1065,6 +1065,36 @@ var GempLotrHallUI = Class.extend({
 							}
 						}
 					}
+
+					var prizesBut = $("<button>Show Prizes</button>");
+					$(prizesBut).button().click((
+						function(queueInfo) {
+							return function() {
+								var infoDialog = $("<div></div>")
+                                				.dialog({
+                                					autoOpen:false,
+                                					closeOnEscape:true,
+                                					resizable:false,
+                                					title:"Prizes details",
+                                					closeText: ""
+                                				});
+
+								var prizeDescription = $(queueInfo.getAttribute("prizes")).attr("value");
+								if (prizeDescription) {
+									infoDialog.html(prizeDescription);
+								} else {
+									infoDialog.html("<p>No prize information available.</p>");
+								}
+
+								infoDialog.html(prizeDescription);
+
+								infoDialog.dialog({width: 300, height: 150});
+								infoDialog.dialog("open");
+							}
+						})(queue));
+					actionsField.append(prizesBut);
+
+
 					var type = queue.getAttribute("type");
 					if(type !== null)
 						type = type.toLowerCase();

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/sealed/sealed_formats.hjson
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/sealed/sealed_formats.hjson
@@ -492,6 +492,7 @@
 		name: 15 Single Series Fellowship Block Sealed
 		id: single_fotr_block_sealed
 		format: limited_fotr
+		hall: true
 		seriesProduct: [
 			[
 				1x(S)FotR Block Choice - Starter
@@ -509,6 +510,7 @@
 		name: 16 Single Series Towers Block Sealed
 		id: single_ttt_block_sealed
 		format: limited_ttt
+		hall: true
 		seriesProduct: [
 			[
 				1x(S)TTT Block Choice - Starter
@@ -526,6 +528,7 @@
 		name: 17 Single Series Towers Standard Sealed
 		id: single_ts_sealed
 		format: limited_ttt
+		hall: true
 		seriesProduct: [
 			[
 				1x(S)TS Special Choice - Starter
@@ -544,6 +547,7 @@
 		name: 18 Single Series King Block Sealed
 		id: single_rotk_block_sealed
 		format: limited_king
+		hall: true
 		seriesProduct: [
 			[
 				1x(S)RotK Block Choice - Starter
@@ -567,6 +571,7 @@
 		name: 19 Single Series Movie Sealed
 		id: single_movie_sealed
 		format: limited_king
+		hall: true
 		seriesProduct: [
 			[
 				1x(S)Movie Special Choice - Starter
@@ -588,6 +593,7 @@
 		name: 20 Single Series War of the Ring Block Sealed
 		id: single_wotr_block_sealed
 		format: limited_shadows
+		hall: true
 		seriesProduct: [
 			[
 				1x(S)WotR Choice - Starter
@@ -611,6 +617,7 @@
 		name: 21 Single Series Hunters Block Sealed
 		id: single_th_block_sealed
 		format: limited_hunters
+		hall: true
 		seriesProduct: [
 			[
 				1x(S)HU Block Choice - Starter

--- a/gemp-lotr/gemp-lotr-common/src/main/java/com/gempukku/lotro/common/JSONDefs.java
+++ b/gemp-lotr/gemp-lotr-common/src/main/java/com/gempukku/lotro/common/JSONDefs.java
@@ -31,6 +31,19 @@ public class JSONDefs {
         }
     }
 
+    public static class LiveDraftInfo {
+        public String code;
+        public String name;
+        public int maxPlayers;
+        public String recommendedTimer;
+        public LiveDraftInfo(String c, String n, int p, String t) {
+            code = c;
+            name = n;
+            maxPlayers = p;
+            recommendedTimer = t;
+        }
+    }
+
     public static class Format {
         public String adventure;
         public String code;
@@ -91,7 +104,7 @@ public class JSONDefs {
     public static class PlayerMadeTournamentAvailableFormats {
         public List<ItemStub> sealed;
         public List<ItemStub> soloDrafts;
-        public List<ItemStub> tableDrafts;
+        public List<LiveDraftInfo> tableDrafts;
         public List<String> draftTimerTypes;
     }
 

--- a/gemp-lotr/gemp-lotr-common/src/main/java/com/gempukku/lotro/common/JSONDefs.java
+++ b/gemp-lotr/gemp-lotr-common/src/main/java/com/gempukku/lotro/common/JSONDefs.java
@@ -88,6 +88,13 @@ public class JSONDefs {
         public List<String> TableDraftTimerTypes;
     }
 
+    public static class PlayerMadeTournamentAvailableFormats {
+        public List<ItemStub> sealed;
+        public List<ItemStub> soloDrafts;
+        public List<ItemStub> tableDrafts;
+        public List<String> draftTimerTypes;
+    }
+
     public static class TimerType {
         public String type;
     }

--- a/gemp-lotr/gemp-lotr-common/src/main/java/com/gempukku/lotro/common/JSONDefs.java
+++ b/gemp-lotr/gemp-lotr-common/src/main/java/com/gempukku/lotro/common/JSONDefs.java
@@ -20,6 +20,7 @@ public class JSONDefs {
         public String id;
         public String format;
         public List<List<String>> seriesProduct;
+        public boolean hall = false;
     }
 
     public static class ItemStub {

--- a/gemp-lotr/gemp-lotr-common/src/main/java/com/gempukku/lotro/common/JSONDefs.java
+++ b/gemp-lotr/gemp-lotr-common/src/main/java/com/gempukku/lotro/common/JSONDefs.java
@@ -102,6 +102,7 @@ public class JSONDefs {
     }
 
     public static class PlayerMadeTournamentAvailableFormats {
+        public List<ItemStub> constructed;
         public List<ItemStub> sealed;
         public List<ItemStub> soloDrafts;
         public List<LiveDraftInfo> tableDrafts;

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/game/formats/LotroFormatLibrary.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/game/formats/LotroFormatLibrary.java
@@ -21,6 +21,7 @@ public class LotroFormatLibrary {
     private final Map<String, LotroFormat> _hallFormats = new LinkedHashMap<>();
 
     private final Map<String, SealedEventDefinition> _sealedTemplates = new LinkedHashMap<>();
+    private final Map<String, SealedEventDefinition> _hallSealedTemplates = new LinkedHashMap<>();
 
     private final AdventureLibrary _adventureLibrary;
     private final LotroCardBlueprintLibrary _cardLibrary;
@@ -48,6 +49,7 @@ public class LotroFormatLibrary {
         try {
             collectionReady.acquire();
             _sealedTemplates.clear();
+            _hallSealedTemplates.clear();
             loadSealedTemplates(_sealedPath);
             collectionReady.release();
         } catch (InterruptedException e) {
@@ -88,12 +90,15 @@ public class LotroFormatLibrary {
             for (var def : defs) {
                 if(def == null)
                     continue;
-                var sealed = new SealedEventDefinition(def.name, def.id, _allFormats.get(def.format), def.seriesProduct);
+                var sealed = new SealedEventDefinition(def.name, def.id, _allFormats.get(def.format), def.seriesProduct, def.hall);
 
                 if(_sealedTemplates.containsKey(def.id)) {
                     System.out.println("Overwriting existing sealed definition '" + def.id + "'!");
                 }
                 _sealedTemplates.put(def.id, sealed);
+                if (def.hall) {
+                    _hallSealedTemplates.put(def.id, sealed);
+                }
             }
 
         } catch (IOException e) {
@@ -221,6 +226,18 @@ public class LotroFormatLibrary {
         }
         catch (InterruptedException exp) {
             throw new RuntimeException("FormatLibrary.GetSealedTemplate() interrupted: ", exp);
+        }
+    }
+
+    public Map<String, SealedEventDefinition> getAllHallSealedTemplates() {
+        try {
+            collectionReady.acquire();
+            var data = Collections.unmodifiableMap(_hallSealedTemplates);
+            collectionReady.release();
+            return data;
+        }
+        catch (InterruptedException exp) {
+            throw new RuntimeException("FormatLibrary.getAllHallSealedTemplates() interrupted: ", exp);
         }
     }
 

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/game/formats/LotroFormatLibrary.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/game/formats/LotroFormatLibrary.java
@@ -241,6 +241,26 @@ public class LotroFormatLibrary {
         }
     }
 
+    public boolean toggleSealedInHall(String code) {
+        try {
+            collectionReady.acquire();
+            boolean tbr = false;
+            if (_hallSealedTemplates.containsKey(code)) {
+                _hallSealedTemplates.remove(code);
+            } else if (_sealedTemplates.containsKey(code)) {
+                _hallSealedTemplates.put(code, _sealedTemplates.get(code));
+                tbr = true;
+            }
+
+            collectionReady.release();
+            return tbr;
+        }
+        catch (InterruptedException exp) {
+            throw new RuntimeException("FormatLibrary.toggleSealedInHall() interrupted: ", exp);
+        }
+
+    }
+
     public SealedEventDefinition GetSealedTemplateByFormatCode(String formatCode) {
         try {
             collectionReady.acquire();

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallCommunicationChannel.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallCommunicationChannel.java
@@ -107,7 +107,7 @@ public class HallCommunicationChannel implements LongPollableResource {
                     @Override
                     public void visitTournamentQueue(String tournamentQueueKey, int cost, String collectionName, String formatName, String type, String tournamentQueueName,
                                                      String tournamentPrizes, String pairingDescription, String startCondition, int playerCount, String playerList, boolean playerSignedUp,
-                                                     boolean joinable, boolean startable, int readyCheckSecsRemaining, boolean confirmedReadyCheck, boolean wc) {
+                                                     boolean joinable, boolean startable, int readyCheckSecsRemaining, boolean confirmedReadyCheck, boolean wc, String draftCode) {
                         Map<String, String> props = new HashMap<>();
                         props.put("cost", String.valueOf(cost));
                         props.put("collection", collectionName);
@@ -125,8 +125,8 @@ public class HallCommunicationChannel implements LongPollableResource {
                         props.put("readyCheckSecsRemaining", String.valueOf(readyCheckSecsRemaining));
                         props.put("confirmedReadyCheck", String.valueOf(confirmedReadyCheck));
                         props.put("wc", String.valueOf(wc));
-                        if (tournamentQueueKey.contains("table")) {
-                            props.put("draftCode", tournamentQueueKey.replace("_queue", ""));
+                        if (draftCode != null) {
+                            props.put("draftCode", draftCode);
                         }
 
                         tournamentQueuesOnServer.put(tournamentQueueKey, props);

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallCommunicationChannel.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallCommunicationChannel.java
@@ -107,7 +107,8 @@ public class HallCommunicationChannel implements LongPollableResource {
                     @Override
                     public void visitTournamentQueue(String tournamentQueueKey, int cost, String collectionName, String formatName, String type, String tournamentQueueName,
                                                      String tournamentPrizes, String pairingDescription, String startCondition, int playerCount, String playerList, boolean playerSignedUp,
-                                                     boolean joinable, boolean startable, int readyCheckSecsRemaining, boolean confirmedReadyCheck, boolean wc, String draftCode) {
+                                                     boolean joinable, boolean startable, int readyCheckSecsRemaining, boolean confirmedReadyCheck, boolean wc, String draftCode,
+                                                     boolean recurring, boolean scheduled, boolean displayInWaitingTables) {
                         Map<String, String> props = new HashMap<>();
                         props.put("cost", String.valueOf(cost));
                         props.put("collection", collectionName);
@@ -128,6 +129,9 @@ public class HallCommunicationChannel implements LongPollableResource {
                         if (draftCode != null) {
                             props.put("draftCode", draftCode);
                         }
+                        props.put("recurring", String.valueOf(recurring));
+                        props.put("scheduled", String.valueOf(scheduled));
+                        props.put("displayInWaitingTables", String.valueOf(displayInWaitingTables));
 
                         tournamentQueuesOnServer.put(tournamentQueueKey, props);
                     }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallInfoVisitor.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallInfoVisitor.java
@@ -15,7 +15,7 @@ public interface HallInfoVisitor {
 
     public void visitTournamentQueue(String tournamentQueueKey, int cost, String collectionName, String formatName, String type, String tournamentQueueName, String tournamentPrizes,
                                      String pairingDescription, String startCondition, int playerCount, String playerList, boolean playerSignedUp, boolean joinable, boolean startable,
-                                     int readyCheckSecsRemaining, boolean confirmedReadyCheck, boolean wc);
+                                     int readyCheckSecsRemaining, boolean confirmedReadyCheck, boolean wc, String draftCode);
 
     public void visitTournament(String tournamentKey, String collectionName, String formatName, String tournamentName, String type,
                                 String pairingDescription, String tournamentStage, int round, int playerCount, String playerList, boolean playerInCompetition, boolean abandoned, boolean joinable,

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallInfoVisitor.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallInfoVisitor.java
@@ -15,7 +15,8 @@ public interface HallInfoVisitor {
 
     public void visitTournamentQueue(String tournamentQueueKey, int cost, String collectionName, String formatName, String type, String tournamentQueueName, String tournamentPrizes,
                                      String pairingDescription, String startCondition, int playerCount, String playerList, boolean playerSignedUp, boolean joinable, boolean startable,
-                                     int readyCheckSecsRemaining, boolean confirmedReadyCheck, boolean wc, String draftCode);
+                                     int readyCheckSecsRemaining, boolean confirmedReadyCheck, boolean wc, String draftCode, boolean recurring, boolean scheduled,
+                                     boolean displayInWaitingTables);
 
     public void visitTournament(String tournamentKey, String collectionName, String formatName, String tournamentName, String type,
                                 String pairingDescription, String tournamentStage, int round, int playerCount, String playerList, boolean playerInCompetition, boolean abandoned, boolean joinable,

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallServer.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallServer.java
@@ -21,10 +21,7 @@ import com.gempukku.lotro.logic.GameUtils;
 import com.gempukku.lotro.logic.timing.GameResultListener;
 import com.gempukku.lotro.logic.vo.LotroDeck;
 import com.gempukku.lotro.service.AdminService;
-import com.gempukku.lotro.tournament.Tournament;
-import com.gempukku.lotro.tournament.TournamentCallback;
-import com.gempukku.lotro.tournament.TournamentQueue;
-import com.gempukku.lotro.tournament.TournamentService;
+import com.gempukku.lotro.tournament.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -476,6 +473,21 @@ public class HallServer extends AbstractServer {
         }
     }
 
+
+    public boolean addPlayerMadeLimitedQueue(TournamentInfo info, Player player, boolean startableEarly, int readyCheckTimeSecs) throws SQLException, IOException {
+        _hallDataAccessLock.writeLock().lock();
+        try {
+            boolean success = _tournamentService.addPlayerMadeLimitedQueue(info, player, startableEarly, readyCheckTimeSecs);
+            if (success) {
+                hallChanged();
+            }
+            return success;
+        } finally {
+            _hallDataAccessLock.writeLock().unlock();
+        }
+
+    }
+
     public void leaveQueue(String queueId, Player player) throws SQLException, IOException {
         _hallDataAccessLock.writeLock().lock();
         try {
@@ -916,9 +928,9 @@ public class HallServer extends AbstractServer {
         private HallTournamentCallback(Tournament tournament) {
             tournamentId = tournament.getTournamentId();
             tournamentName = tournament.getTournamentName();
-            // Tournaments with no prizes and no entry are not competitive
+            // Tournaments with no prizes or with 'casual' in their names are not competitive
             boolean casual = tournament.getInfo().Parameters().prizes == Tournament.PrizeType.NONE
-                            && tournament.getInfo().Parameters().cost == 0;
+                            || tournamentName.toLowerCase().contains("casual");
 
             if (tournament.isWC()) {
                 gameSettings = new GameSettings(null, _formatLibrary.getFormat(tournament.getFormatCode()),

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallServer.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/hall/HallServer.java
@@ -474,10 +474,15 @@ public class HallServer extends AbstractServer {
     }
 
 
-    public boolean addPlayerMadeLimitedQueue(TournamentInfo info, Player player, boolean startableEarly, int readyCheckTimeSecs) throws SQLException, IOException {
+    public boolean addPlayerMadeQueue(TournamentInfo info, Player player, String deckName, boolean startableEarly, int readyCheckTimeSecs) throws SQLException, IOException, HallException {
         _hallDataAccessLock.writeLock().lock();
         try {
-            boolean success = _tournamentService.addPlayerMadeLimitedQueue(info, player, startableEarly, readyCheckTimeSecs);
+            LotroDeck lotroDeck = null;
+            if (info.Parameters().requiresDeck) {
+                lotroDeck = validateUserAndDeck(info.Format, player, deckName, info.Collection);
+            }
+
+            boolean success = _tournamentService.addPlayerMadeQueue(info, player, lotroDeck, startableEarly, readyCheckTimeSecs);
             if (success) {
                 hallChanged();
             }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/league/SealedEventDefinition.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/league/SealedEventDefinition.java
@@ -14,11 +14,13 @@ public class SealedEventDefinition {
     private final String _id;
     private final LotroFormat _format;
     private final List<List<CardCollection.Item>> _seriesProduct = new ArrayList<>();
+    private final boolean _hallVisible;
 
-    public SealedEventDefinition(String name, String id, LotroFormat format, List<List<String>> product) {
+    public SealedEventDefinition(String name, String id, LotroFormat format, List<List<String>> product, boolean hallVisible) {
         _name = name;
         _id = id;
         _format = format;
+        _hallVisible = hallVisible;
 
         for(var serie : product) {
             List<CardCollection.Item> items = new ArrayList<>();
@@ -47,6 +49,7 @@ public class SealedEventDefinition {
            seriesProduct = _seriesProduct.stream()
                    .map(x->x.stream().map(CardCollection.Item::toString).collect(Collectors.toList()))
                    .collect(Collectors.toList());
+           hall = _hallVisible;
         }};
     }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/AbstractTournamentQueue.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/AbstractTournamentQueue.java
@@ -189,6 +189,7 @@ public abstract class AbstractTournamentQueue implements TournamentQueue {
         tbr.minimumPlayers = _tournamentInfo._params.minimumPlayers;
         tbr.maximumPlayers = _tournamentInfo._params.maximumPlayers;
         tbr.requiresDeck = _tournamentInfo._params.requiresDeck;
+        tbr.wc = _tournamentInfo._params.wc;
 
         return tbr;
     }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/AbstractTournamentQueue.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/AbstractTournamentQueue.java
@@ -420,4 +420,12 @@ public abstract class AbstractTournamentQueue implements TournamentQueue {
     public boolean isWC() {
         return _tournamentInfo._params.wc;
     }
+
+    @Override
+    public String getDraftCode() {
+        if (_tournamentInfo instanceof TableDraftTournamentInfo) {
+            return ((TableDraftTournamentInfo) _tournamentInfo).tableDraftDefinition.getCode();
+        }
+        return null;
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/AbstractTournamentQueue.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/AbstractTournamentQueue.java
@@ -283,7 +283,11 @@ public abstract class AbstractTournamentQueue implements TournamentQueue {
 
     @Override
     public String getPlayerList() {
-        return _playerList;
+        if (_tournamentQueueName.toLowerCase().contains("competitive")) {
+            return "Competitive, player count: " + _players.size();
+        } else {
+            return _playerList;
+        }
     }
 
     @Override

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/ConstructedTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/ConstructedTournament.java
@@ -142,6 +142,6 @@ public class ConstructedTournament extends BaseTournament implements Tournament 
         if (isWC()) {
             return DateUtils.Now().getYear() + " World Championship";
         }
-        return null;
+        return "Tournament Game - " + _tournamentInfo.Format.getName();
     }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/DailyTournamentPrizes.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/DailyTournamentPrizes.java
@@ -76,6 +76,12 @@ public class DailyTournamentPrizes implements TournamentPrizes {
     @Override
     public String getPrizeDescription() {
         return """
-            <div class='prizeHint' value='<ul><li>1st - 10 random foil cards, 4 Tengwar selection, 3 High Place Event Reward</li><li>2nd - 8 random foil cards, 3 Tengwar selection, 2 High Place Event Reward</li><li>3rd - 6 random foil cards, 2 Tengwar selection, 1 High Place Event Reward</li><li>4th - 4 random foil cards, 1 Tengwar selection</li><li>5th-8th - 3 random foil cards</li><li>9th-16th - 2 random foil cards</li><li>17th-32nd - 1 random foil card</li></ul>'>Prize Breakdown</div>""";
+                <div class='prizeHint' value='<ul>
+                    <li>2+ Wins: Required for Event Awards and Tengwar cards</li>
+                    <li>Top 4: Get Tengwar cards (up to 4 for 1st place)</li>
+                    <li>Top 10: Get Event Award (up to 10 for 1st place)</li>
+                    <li>Top 32: Receive random foils (more for higher placement)</li>
+                </ul>'>Prize Breakdown</div>
+                """;
     }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/ImmediateRecurringQueue.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/ImmediateRecurringQueue.java
@@ -2,6 +2,7 @@ package com.gempukku.lotro.tournament;
 
 import com.gempukku.lotro.collection.CollectionsManager;
 
+// Made obsolete by PlayerMadeQueue -> those queues have no longer support in ui and won't be displayed if empty
 public class ImmediateRecurringQueue extends AbstractTournamentQueue implements TournamentQueue {
     private final int _playerCap;
     private final int maxPlayers;
@@ -42,5 +43,10 @@ public class ImmediateRecurringQueue extends AbstractTournamentQueue implements 
     @Override
     public boolean isJoinable() {
         return (maxPlayers < 0 || _players.size() < maxPlayers);
+    }
+
+    @Override
+    public boolean shouldBeDisplayedAsWaiting() {
+        return _players.size() > 0;
     }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/LimitedTournamentPrizes.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/LimitedTournamentPrizes.java
@@ -1,0 +1,49 @@
+package com.gempukku.lotro.tournament;
+
+import com.gempukku.lotro.competitive.PlayerStanding;
+import com.gempukku.lotro.game.CardCollection;
+import com.gempukku.lotro.game.DefaultCardCollection;
+import com.gempukku.lotro.packs.ProductLibrary;
+
+public class LimitedTournamentPrizes implements TournamentPrizes {
+    private final String _registryRepresentation;
+    private final ProductLibrary _productLibrary;
+
+    public LimitedTournamentPrizes(String registryRepresentation, ProductLibrary productLibrary) {
+        _registryRepresentation = registryRepresentation;
+        _productLibrary = productLibrary;
+    }
+
+    @Override
+    public CardCollection getPrizeForTournament(PlayerStanding playerStanding, int playersCount) {
+        // If atleast 4 players, get one reward for each win or bye
+        if (playersCount < 4) {
+            return null;
+        }
+
+        DefaultCardCollection prize = new DefaultCardCollection();
+        int hasBye = playerStanding.byeRound > 0 ? 1 : 0;
+        int numberOfWins = playerStanding.playerWins + hasBye;
+        prize.addItem("Placement Random Chase Card Selector", numberOfWins, true);
+
+        if (prize.getAll().iterator().hasNext())
+            return prize;
+        return null;
+    }
+
+    @Override
+    public CardCollection getTrophyForTournament(PlayerStanding playerStanding, int playersCount) {
+        return null;
+    }
+
+    @Override
+    public String getRegistryRepresentation() {
+        return _registryRepresentation;
+    }
+
+    @Override
+    public String getPrizeDescription() {
+        return """
+            <div class='prizeHint' value='If 4+ players, get one Event Award for each win or bye'>Prize Breakdown</div>""";
+    }
+}

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/PlayerMadeLimitedQueue.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/PlayerMadeLimitedQueue.java
@@ -9,9 +9,6 @@ public class PlayerMadeLimitedQueue extends AbstractTournamentQueue implements T
     public PlayerMadeLimitedQueue(TournamentService tournamentService, String queueId, String queueName, TournamentInfo info, boolean startableEarly, int readyCheckTimeSecs,
                                   TournamentQueueCallback tournamentQueueCallback, CollectionsManager collectionsManager) {
         super(tournamentService, queueId, queueName, info, startableEarly, readyCheckTimeSecs, tournamentQueueCallback, collectionsManager, true);
-        System.out.println("PLAYER MADE QUEUE");
-        System.out.println(queueId);
-        System.out.println(queueName);
     }
 
     @Override

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/PlayerMadeLimitedQueue.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/PlayerMadeLimitedQueue.java
@@ -1,0 +1,49 @@
+package com.gempukku.lotro.tournament;
+
+import com.gempukku.lotro.collection.CollectionsManager;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+public class PlayerMadeLimitedQueue extends AbstractTournamentQueue implements TournamentQueue {
+    public PlayerMadeLimitedQueue(TournamentService tournamentService, String queueId, String queueName, TournamentInfo info, boolean startableEarly, int readyCheckTimeSecs,
+                                  TournamentQueueCallback tournamentQueueCallback, CollectionsManager collectionsManager) {
+        super(tournamentService, queueId, queueName, info, startableEarly, readyCheckTimeSecs, tournamentQueueCallback, collectionsManager, true);
+        System.out.println("PLAYER MADE QUEUE");
+        System.out.println(queueId);
+        System.out.println(queueName);
+    }
+
+    @Override
+    public String getStartCondition() {
+        String playerLimit = "When " + getInfo()._params.maximumPlayers + " players join";
+        String orRequest = " or when start is requested";
+        if (isStartableEarly()) {
+            return playerLimit + orRequest;
+        } else {
+            return playerLimit;
+        }
+    }
+
+    @Override
+    public boolean process() throws SQLException, IOException {
+        if (shouldDestroy) {
+            return true; // Tournament started by Ready Check already, destroy the queue
+        }
+
+        if (_players.isEmpty()) {
+            return true; // All players left, destroy the queue
+        }
+
+        if (_players.size() < getInfo()._params.maximumPlayers)
+            return false; // Do nothing if not enough players
+
+        startTournament();
+        return false; // Do not destroy the queue during possible ready check
+    }
+
+    @Override
+    public boolean isJoinable() {
+        return (getInfo()._params.maximumPlayers < 0 || _players.size() < getInfo()._params.maximumPlayers) && !isReadyCheckTimerRunning();
+    }
+}

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/PlayerMadeQueue.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/PlayerMadeQueue.java
@@ -5,9 +5,9 @@ import com.gempukku.lotro.collection.CollectionsManager;
 import java.io.IOException;
 import java.sql.SQLException;
 
-public class PlayerMadeLimitedQueue extends AbstractTournamentQueue implements TournamentQueue {
-    public PlayerMadeLimitedQueue(TournamentService tournamentService, String queueId, String queueName, TournamentInfo info, boolean startableEarly, int readyCheckTimeSecs,
-                                  TournamentQueueCallback tournamentQueueCallback, CollectionsManager collectionsManager) {
+public class PlayerMadeQueue extends AbstractTournamentQueue implements TournamentQueue {
+    public PlayerMadeQueue(TournamentService tournamentService, String queueId, String queueName, TournamentInfo info, boolean startableEarly, int readyCheckTimeSecs,
+                           TournamentQueueCallback tournamentQueueCallback, CollectionsManager collectionsManager) {
         super(tournamentService, queueId, queueName, info, startableEarly, readyCheckTimeSecs, tournamentQueueCallback, collectionsManager, true);
     }
 

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/PlayerMadeQueue.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/PlayerMadeQueue.java
@@ -43,4 +43,9 @@ public class PlayerMadeQueue extends AbstractTournamentQueue implements Tourname
     public boolean isJoinable() {
         return (getInfo()._params.maximumPlayers < 0 || _players.size() < getInfo()._params.maximumPlayers) && !isReadyCheckTimerRunning();
     }
+
+    @Override
+    public boolean shouldBeDisplayedAsWaiting() {
+        return true; // Always display player made queues in waiting tables section
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/RecurringScheduledQueue.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/RecurringScheduledQueue.java
@@ -56,6 +56,12 @@ public class RecurringScheduledQueue extends AbstractTournamentQueue implements 
     }
 
     @Override
+    public boolean shouldBeDisplayedAsWaiting() {
+        // Display in waiting tables section 1 hour before start
+        return ZonedDateTime.now().isAfter(_nextStart.minus(_signupTimeBeforeStart));
+    }
+
+    @Override
     public boolean process() throws SQLException, IOException {
         if (ZonedDateTime.now().isAfter(_nextStart)) {
             if (_players.size() >= _minimumPlayers) {

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/ScheduledTournamentQueue.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/ScheduledTournamentQueue.java
@@ -63,4 +63,13 @@ public class ScheduledTournamentQueue extends AbstractTournamentQueue implements
         }
         return DateUtils.Now().isAfter(_startTime.minus(window)) && (maximumPlayers < 0 || _players.size() < maximumPlayers);
     }
+
+    @Override
+    public boolean shouldBeDisplayedAsWaiting() {
+        var window = _signupTimeBeforeStart;
+        if (isWC()) {
+            window = _wcSignupTimeBeforeStart;
+        }
+        return DateUtils.Now().isAfter(_startTime.minus(window));
+    }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SealedTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SealedTournament.java
@@ -280,10 +280,9 @@ public class SealedTournament extends BaseTournament implements Tournament {
 
     @Override
     public String getTableDescription() {
-        if (_sealedInfo._params.prizes == PrizeType.NONE && _sealedInfo._params.cost == 0) {
-            return "Casual - " + _sealedInfo.SealedDefinition.GetName();
-        } else {
-            return "Competitive - " + _sealedInfo.SealedDefinition.GetName();
+        if (isWC()) {
+            return DateUtils.Now().getYear() + " World Championship - " + _sealedInfo.SealedDefinition.GetName().substring(3); // Strip number ordering
         }
+        return "Tournament Game - " + _sealedInfo.SealedDefinition.GetName().substring(3); // Strip number ordering
     }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloDraftTournament.java
@@ -293,10 +293,9 @@ public class SoloDraftTournament extends BaseTournament implements Tournament {
 
     @Override
     public String getTableDescription() {
-        if (_soloDraftInfo._params.prizes == PrizeType.NONE && _soloDraftInfo._params.cost == 0) {
-            return "Casual - " + _soloDraftLibrary.getSoloDraft(_soloDraftInfo._soloDraftParams.soloDraftFormatCode).getCode();
-        } else {
-            return "Competitive - " + _soloDraftLibrary.getSoloDraft(_soloDraftInfo._soloDraftParams.soloDraftFormatCode).getCode();
+        if (isWC()) {
+            return DateUtils.Now().getYear() + " World Championship - " + _soloDraftLibrary.getSoloDraft(_soloDraftInfo._soloDraftParams.soloDraftFormatCode).getCode();
         }
+        return "Tournament Game - " + _soloDraftLibrary.getSoloDraft(_soloDraftInfo._soloDraftParams.soloDraftFormatCode).getCode();
     }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloTableDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/SoloTableDraftTournament.java
@@ -268,10 +268,9 @@ public class SoloTableDraftTournament extends BaseTournament implements Tourname
 
     @Override
     public String getTableDescription() {
-        if (soloTableDraftInfo._params.prizes == PrizeType.NONE && soloTableDraftInfo._params.cost == 0) {
-            return "Casual - " + _tableDraftLibrary.getTableDraftDefinition(soloTableDraftInfo.soloTableDraftParams.soloTableDraftFormatCode).getName();
-        } else {
-            return "Competitive - " + _tableDraftLibrary.getTableDraftDefinition(soloTableDraftInfo.soloTableDraftParams.soloTableDraftFormatCode).getName();
+        if (isWC()) {
+            return DateUtils.Now().getYear() + " World Championship - " + _tableDraftLibrary.getTableDraftDefinition(soloTableDraftInfo.soloTableDraftParams.soloTableDraftFormatCode).getName();
         }
+        return "Tournament Game - " + _tableDraftLibrary.getTableDraftDefinition(soloTableDraftInfo.soloTableDraftParams.soloTableDraftFormatCode).getName();
     }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TableDraftTournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TableDraftTournament.java
@@ -290,10 +290,9 @@ public class TableDraftTournament extends BaseTournament implements Tournament {
 
     @Override
     public String getTableDescription() {
-        if (tableDraftInfo._params.prizes == PrizeType.NONE && tableDraftInfo._params.cost == 0) {
-            return "Casual - " + _tableDraftLibrary.getTableDraftDefinition(tableDraftInfo.tableDraftParams.tableDraftFormatCode).getName();
-        } else {
-            return "Competitive - " + _tableDraftLibrary.getTableDraftDefinition(tableDraftInfo.tableDraftParams.tableDraftFormatCode).getName();
+        if (isWC()) {
+            return DateUtils.Now().getYear() + " World Championship - " + _tableDraftLibrary.getTableDraftDefinition(tableDraftInfo.tableDraftParams.tableDraftFormatCode).getName();
         }
+        return "Tournament Game - " + _tableDraftLibrary.getTableDraftDefinition(tableDraftInfo.tableDraftParams.tableDraftFormatCode).getName();
     }
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/Tournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/Tournament.java
@@ -87,7 +87,8 @@ public interface Tournament {
     enum PrizeType {
         NONE,
         DAILY,
-        ON_DEMAND;
+        ON_DEMAND,
+        LIMITED;
 
         public static PrizeType parse(String name) {
             String nameCaps = name.toUpperCase().trim().replace(' ', '_').replace('-', '_');
@@ -109,6 +110,9 @@ public interface Tournament {
             case ON_DEMAND -> {
                 //Currently busted, reverting to Daily for now
                 return new DailyTournamentPrizes(prize.name(), productLibrary);
+            }
+            case LIMITED -> {
+                return new LimitedTournamentPrizes(prize.name(), productLibrary);
             }
         }
 

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/Tournament.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/Tournament.java
@@ -88,7 +88,7 @@ public interface Tournament {
         NONE,
         DAILY,
         ON_DEMAND,
-        LIMITED;
+        WIN_GAME_FOR_AWARD;
 
         public static PrizeType parse(String name) {
             String nameCaps = name.toUpperCase().trim().replace(' ', '_').replace('-', '_');
@@ -111,8 +111,8 @@ public interface Tournament {
                 //Currently busted, reverting to Daily for now
                 return new DailyTournamentPrizes(prize.name(), productLibrary);
             }
-            case LIMITED -> {
-                return new LimitedTournamentPrizes(prize.name(), productLibrary);
+            case WIN_GAME_FOR_AWARD -> {
+                return new WinForAwardTournamentPrizes(prize.name(), productLibrary);
             }
         }
 

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentQueue.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentQueue.java
@@ -56,4 +56,6 @@ public interface TournamentQueue {
     boolean isWC();
 
     String getDraftCode();
+
+    boolean shouldBeDisplayedAsWaiting();
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentQueue.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentQueue.java
@@ -30,6 +30,8 @@ public interface TournamentQueue {
 
     void joinPlayer(Player player, LotroDeck deck) throws SQLException, IOException;
 
+    void joinPlayer(Player player) throws SQLException, IOException;
+
     void leavePlayer(Player player) throws SQLException, IOException;
 
     void leaveAllPlayers() throws SQLException, IOException;

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentQueue.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentQueue.java
@@ -54,4 +54,6 @@ public interface TournamentQueue {
     boolean hasConfirmedReadyCheck(String player);
 
     boolean isWC();
+
+    String getDraftCode();
 }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
@@ -7,7 +7,6 @@ import com.gempukku.lotro.common.DBDefs;
 import com.gempukku.lotro.db.GameHistoryDAO;
 import com.gempukku.lotro.db.vo.CollectionType;
 import com.gempukku.lotro.draft2.SoloDraftDefinitions;
-import com.gempukku.lotro.draft3.TableDraftDefinition;
 import com.gempukku.lotro.draft3.TableDraftDefinitions;
 import com.gempukku.lotro.game.LotroCardBlueprintLibrary;
 import com.gempukku.lotro.game.Player;
@@ -99,14 +98,6 @@ public class TournamentService {
 
     public void reloadQueues() {
         _tournamentQueues.clear();
-
-        addImmediateRecurringQueue("fotr_queue", "Fellowship Block", "fotr-", "fotr_block");
-        addImmediateRecurringQueue("pc_fotr_queue", "PC-Fellowship", "pcfotr-", "pc_fotr_block");
-        addImmediateRecurringQueue("ts_queue", "Towers Standard", "ts-", "towers_standard");
-        addImmediateRecurringQueue("movie_queue", "Movie Block", "movie-", "movie");
-        addImmediateRecurringQueue("pc_movie_queue", "PC-Movie", "pcmovie-", "pc_movie");
-        addImmediateRecurringQueue("expanded_queue", "Expanded", "expanded-", "expanded");
-        addImmediateRecurringQueue("pc_expanded_queue", "PC-Expanded", "pcexpanded-", "pc_expanded");
 
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
@@ -296,16 +287,20 @@ public class TournamentService {
         return true;
     }
 
-    public boolean addPlayerMadeLimitedQueue(TournamentInfo info, Player player, boolean startableEarly, int readyCheckTimeSecs) throws SQLException, IOException {
+    public boolean addPlayerMadeQueue(TournamentInfo info, Player player, LotroDeck lotroDeck, boolean startableEarly, int readyCheckTimeSecs) throws SQLException, IOException {
         if (_tournamentQueues.containsKey(info._params.tournamentId))
             return false;
 
-        TournamentQueue tournamentQueue = new PlayerMadeLimitedQueue(this, info.Parameters().tournamentId,
+        TournamentQueue tournamentQueue = new PlayerMadeQueue(this, info.Parameters().tournamentId,
                 info.Parameters().name, info, startableEarly, readyCheckTimeSecs,
                 tournament -> _activeTournaments.put(tournament.getTournamentId(), tournament), _collectionsManager);
         _tournamentQueues.put(info._params.tournamentId, tournamentQueue);
 
-        tournamentQueue.joinPlayer(player);
+        if (info._params.requiresDeck) {
+            tournamentQueue.joinPlayer(player, lotroDeck);
+        } else {
+            tournamentQueue.joinPlayer(player);
+        }
 
         return true;
     }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
@@ -404,6 +404,20 @@ public class TournamentService {
         return true;
     }
 
+    public boolean addPlayerMadeLimitedQueue(TournamentInfo info, Player player, boolean startableEarly, int readyCheckTimeSecs) throws SQLException, IOException {
+        if (_tournamentQueues.containsKey(info._params.tournamentId))
+            return false;
+
+        TournamentQueue tournamentQueue = new PlayerMadeLimitedQueue(this, info.Parameters().tournamentId,
+                info.Parameters().name, info, startableEarly, readyCheckTimeSecs,
+                tournament -> _activeTournaments.put(tournament.getTournamentId(), tournament), _collectionsManager);
+        _tournamentQueues.put(info._params.tournamentId, tournamentQueue);
+
+        tournamentQueue.joinPlayer(player);
+
+        return true;
+    }
+
     public TournamentQueue getTournamentQueue(TournamentInfo info) {
         TournamentQueueCallback callback = tournament -> _activeTournaments.put(tournament.getTournamentId(), tournament);
 

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
@@ -159,7 +159,8 @@ public class TournamentService {
                     formatLibrary.getFormat(queue.getFormatCode()).getName(), queue.getInfo().Parameters().type.toString(), queue.getTournamentQueueName(),
                     queue.getPrizesDescription(), queue.getPairingDescription(), queue.getStartCondition(),
                     queue.getPlayerCount(), queue.getPlayerList(), queue.isPlayerSignedUp(player.getName()), queue.isJoinable(), queue.isStartable(player.getName()),
-                    queue.getSecondsRemainingForReadyCheck(), queue.hasConfirmedReadyCheck(player.getName()), queue.isWC(), queue.getDraftCode());
+                    queue.getSecondsRemainingForReadyCheck(), queue.hasConfirmedReadyCheck(player.getName()), queue.isWC(), queue.getDraftCode(),
+                    queue instanceof RecurringScheduledQueue, queue instanceof ScheduledTournamentQueue, queue.shouldBeDisplayedAsWaiting());
         }
 
         for (var entry : _activeTournaments.entrySet()) {

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/TournamentService.java
@@ -135,6 +135,9 @@ public class TournamentService {
             // Ignore, can't happen
             System.out.println(exp);
         }
+
+        // Add scheduled queues from DB
+        refreshQueues();
     }
 
     public void cancelAllTournamentQueues() throws SQLException, IOException {

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/WinForAwardTournamentPrizes.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/WinForAwardTournamentPrizes.java
@@ -5,11 +5,11 @@ import com.gempukku.lotro.game.CardCollection;
 import com.gempukku.lotro.game.DefaultCardCollection;
 import com.gempukku.lotro.packs.ProductLibrary;
 
-public class LimitedTournamentPrizes implements TournamentPrizes {
+public class WinForAwardTournamentPrizes implements TournamentPrizes {
     private final String _registryRepresentation;
     private final ProductLibrary _productLibrary;
 
-    public LimitedTournamentPrizes(String registryRepresentation, ProductLibrary productLibrary) {
+    public WinForAwardTournamentPrizes(String registryRepresentation, ProductLibrary productLibrary) {
         _registryRepresentation = registryRepresentation;
         _productLibrary = productLibrary;
     }

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/WinForAwardTournamentPrizes.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/tournament/WinForAwardTournamentPrizes.java
@@ -25,6 +25,10 @@ public class WinForAwardTournamentPrizes implements TournamentPrizes {
         int hasBye = playerStanding.byeRound > 0 ? 1 : 0;
         int numberOfWins = playerStanding.playerWins + hasBye;
         prize.addItem("Placement Random Chase Card Selector", numberOfWins, true);
+        // The winner also gets one tengwar card
+        if (playerStanding.standing == 1) {
+            prize.addItem("(S)Tengwar", 1, true);
+        }
 
         if (prize.getAll().iterator().hasNext())
             return prize;
@@ -44,6 +48,10 @@ public class WinForAwardTournamentPrizes implements TournamentPrizes {
     @Override
     public String getPrizeDescription() {
         return """
-            <div class='prizeHint' value='If 4+ players, get one Event Award for each win or bye'>Prize Breakdown</div>""";
+                <div class='prizeHint' value='<ul>
+                    <li>4+ Players required for any prizes</li>
+                    <li>1 Event Award per win or bye</li>
+                    <li>1 Tengwar card for the tournament winner</li>
+                </ul>'>Prize Breakdown</div>""";
     }
 }


### PR DESCRIPTION
# Summary
This PR gets rid of immediately recurring tournament queues, and replaces them with player made queues. Some things were moved around in the Hall.

# Changes
If possible, the listed changes can be also seen in the screenshots section below.

### Hall
-  Section removed: Active Tournaments and WC Events - Active tournaments (including WC events) no longer have their separate section, they are now only displayed in the 'playing tables' section
- Section removed: Sealed Games and Draft Games - Immediately recurring queues were displayed in those areas and those are no longer being used
- Sectioned removed: Tournament Queues - Immediately recurring constructed queues were there (those are no more), as well as recurring scheduled queues (daily tournaments) and scheduled queues (those made by admins), which are displayed in new sections
- Section added: Recurring Events - Displays all recurring queues (daily tournaments)
- Section added: Scheduled Events - Displays all scheduled queues (made by admins), does not include WC queues, which still have their own separate section for visibility
- Section added: Create Tournaments & Limited Games - Displays form that allows players to make their own tournament queues (both constructed and limited)
- Hall section headers contain disclosure triangles to visualize if they are collapsed or not
- Player made queues always appear in waiting tables section (they are destroyed if all players leave)
- Recurring and scheduled queues are displayed in waiting tables section if it is past their signup time (1 hour in advance for non-wc queues, 30 hours for wc queues) even if 0 players are in the queue
- WC queues and tournaments use bold font to make them stand out more (the red wc queues section is still present)
- WC queues and tournaments use 'World Championship' instead of 'WC'
- Games spawned by tournaments have better table info description
- WC queues and scheduled events sections are now added in JS instead of html to prevent them from appearing and then being gone if no tournaments are scheduled
- Tournament queues now display info about pairing system (swiss/elim) in their table info field in waiting tables section
- Removed the actions field (buttons) from queues sections - queues can now only be joined from the waiting tables section
- Limited tournament's player list contains check marks to show who submitted a deck only during deck building and deck registration phase (this cannot be seen on the screenshots, made the change while writing this PR)

### Tournaments
 - Tournaments that have 'casual' (not case sensitive) in their names spawn tables that can be spectated
 - Tournament queues that have 'competitive' (not case sensitive) in their names do not display names of signed-up players before tournament starts
 - Added new recurring event - weekly fotr live draft (starts saturday 17:00 server time)

### Create Tournaments & Limited Games Section
 - New form in the hall that allows players to make their own (non scheduled) tournaments
 - Supported game types: constructed, sealed, solo draft, live draft
 - Allowed constructed formats: hall visible
 - Allowed drafts: all live drafts, all solo drafts (except one hobbit draft, there are two defined)
 - Allowed sealed formats: hall visible (defined in sealed json), default are all single series block sealeds + movie and TS sealed
 - Hall visible sealed formats can be modified in tournament admin's ui (does not persist after server restart or json reaload)
 - Players can choose game type, format and desired number of players (checks maximum table size for live drafts)
 - If needed/wanted, players can click 'Show advanced settings' to display more options
 - Those advanced options are pairing type (swiss, single elimination), competitive level (games can be spectated, visible names in queue), early start option (if tournament can start with less players than originally requested if owner presses the button), ready check option (if there will be ready check and how long), deck building time (for limited games) and draft timer (for live draft games)
 - All those advanced options have default values filled based on game type and format selected (my personal choices - for example live draft of hobbit uses slower draft timer than fotr draft)
 - All tournaments created by this form (both constructed and limited) use new 'WinForAward' prize system (4+ Players required for any prizes, 1 Event Award per game win or bye, 1 Tengwar card for the tournament winner) which gives out way less prizes than daily, but 4 player tournament is no longer 'winner takes it all' situation
 - If making constructed tournament, correct deck needs to be selected when pressing the create button in deck selector (error will pop up if deck for wrong format is selected)

### Fixes
 - Scheduled queues form (tournament admin ui) now checks if there are no spaces in tournament id
 - Daily tournament prizes description fix
 - Fixed messed up indents in hall js
 - When server restarts, scheduled queues (including wc) are now loaded from db immediately instead of with one minute delay

# Screenshots
New empty hall with all sections visible - no scheduled events and no wc events section since none are scheduled.
Also shows the missing actions column for recurring queues (if it would be less than 1 hour til start, the queues would be also in waiting tables section, and the join button would be there) and new weekly live draft tournament.
![image](https://github.com/user-attachments/assets/58eb653f-cac6-40e8-8972-2b41ad1ef2e8)

When game type is selected in tournament form, more fields appear, including 'Show advanced settings' button - the create button is disabled as no format is selected by default.
![image](https://github.com/user-attachments/assets/5a31987e-bee5-491b-9942-47e2efd42ee1)

View with advanced settings.
![image](https://github.com/user-attachments/assets/2abba0a0-7f7e-498b-aafb-9053b307709f)

Confirmation after selecting format and pressing the create button.
![image](https://github.com/user-attachments/assets/eca50f65-54ed-4e37-9657-14f0534b28f4)

Player made queue is only displayed in waiting tables section. Shows info about it being a swiss tournament. Also the 'Show Prizes' button is new (it does the same as clicking the blue 'prize breakdown' text).
![image](https://github.com/user-attachments/assets/256c71cc-a14b-4f1b-a750-0c0b82bc7576)

Showcase of queue with competitive settings that hides names in queue.
![image](https://github.com/user-attachments/assets/116bcafc-714a-4c01-9ac4-c61dc9277529)

Scheduled tournaments - one to begin soon (is displayed in waiting tables and can be joined), one to being in two days (not displayed in waiting tables, but info when it starts can be seen in scheduled events section)
![image](https://github.com/user-attachments/assets/b5eb8199-7d47-434c-84e4-0ed8dd09f8ae)

WC queue still has its own section with red header to attract attention. Because WC has longer signup of 30 hours, it can already be seen in waiting tables section, even when it begins tomorrow. Notice its text in waiting tables being bold.
![image](https://github.com/user-attachments/assets/7041a649-6820-4e3e-8a3c-9144da9c93a5)

Tournament being displayed only in playing tables section (info about round number is new there) + better description for tables of tournament games.
![image](https://github.com/user-attachments/assets/a785d9f9-6037-4c98-96ec-7dbea37c8764)

Admin UI to toggle sealed formats for open play.
![image](https://github.com/user-attachments/assets/8851f23f-28c3-42b0-8e34-1a75ab0a38d4)

# Testing done
Written tests are passing.
Tested only manually without structure with just 2 players being logged in at the same time. Everything works as far as i can tell. This is a larger PR, if there will be some issues when deployed (like last time with live drafts) i will fix it as soon as possible.