### PR TITLE
Devops cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-target/
+# Maven
+**/target/
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup
@@ -7,19 +8,45 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
-# https://github.com/takari/maven-wrapper#usage-without-binary-jar
 .mvn/wrapper/maven-wrapper.jar
 
+# database files
 database/*
 !database/.placeholder
-logs/*
+
+# log files
+**/logs/
 !logs/.placeholder
-**/logs
-.idea/
-*.iml
-remote-sync
-replay
-!replay/.placeholder
 logs/nohup.out
 nohup.out
-gemp-lotr/docker/docker-compose.yml
+
+# IntelliJ IDEA
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# Eclipse
+.project
+.classpath
+.settings/
+
+# Ignore VS Code transient files
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
+!.vscode/launch.json
+!.vscode/tasks.json
+
+remote-sync
+
+# gemp replay directory
+replay
+!replay/.placeholder
+
+# test output files
+gemp-lotr/gemp-lotr-server/IdealShuffleResult.txt
+
+# MacOS and Windows junk files
+.DS_Store
+Thumbs.db

--- a/gemp-lotr/docker/docker-compose.yml
+++ b/gemp-lotr/docker/docker-compose.yml
@@ -21,32 +21,31 @@ services:
       - target: 8000
         published: 8052
     volumes:
-       - type: bind
-         source: ../gemp-lotr-async/src/main/web
-         target: /etc/gemp-lotr/web
-         consistency: consistent
+      #  - type: bind
+      #    source: ../gemp-lotr-async/src/main/web
+      #    target: /etc/gemp-lotr/web
+      #    consistency: consistent
        - type: bind
          source: ../../gemp-lotr
          target: /etc/gemp-lotr
          consistency: consistent
-       - type: bind
-         source: ../../logs
-         target: /logs
-         consistency: consistent
-       - type: bind
-         source: ../../replay
-         target: /etc/gemp-lotr/replay
-         consistency: consistent
-       - type: bind
-         source: ../../logs/nohup.out
-         target: /etc/gemp-lotr/nohup.out
-         consistency: consistent
+      #  - type: bind
+      #    source: ../../logs
+      #    target: /logs
+      #    consistency: consistent
+      #  - type: bind
+      #    source: ../../replay
+      #    target: /etc/gemp-lotr/replay
+      #    consistency: consistent
+      #  - type: bind
+      #    source: ../../logs/nohup.out
+      #    target: /etc/gemp-lotr/nohup.out
+      #    consistency: consistent
     networks:
       gemp_net_1:
         ipv4_address: ${APP_IP}
     tty: true
-    command: nohup java -jar -Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector /etc/gemp-lotr/gemp-lotr-async/target/web.jar &> /logs/nohup.out &
-
+    command: java -jar -Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector /etc/gemp-lotr/gemp-lotr-async/target/web.jar
 
   db:
     env_file:

--- a/gemp-lotr/docker/docker-compose.yml
+++ b/gemp-lotr/docker/docker-compose.yml
@@ -21,31 +21,32 @@ services:
       - target: 8000
         published: 8052
     volumes:
-      #  - type: bind
-      #    source: ../gemp-lotr-async/src/main/web
-      #    target: /etc/gemp-lotr/web
-      #    consistency: consistent
+       - type: bind
+         source: ../gemp-lotr-async/src/main/web
+         target: /etc/gemp-lotr/web
+         consistency: consistent
        - type: bind
          source: ../../gemp-lotr
          target: /etc/gemp-lotr
          consistency: consistent
-      #  - type: bind
-      #    source: ../../logs
-      #    target: /logs
-      #    consistency: consistent
-      #  - type: bind
-      #    source: ../../replay
-      #    target: /etc/gemp-lotr/replay
-      #    consistency: consistent
-      #  - type: bind
-      #    source: ../../logs/nohup.out
-      #    target: /etc/gemp-lotr/nohup.out
-      #    consistency: consistent
+       - type: bind
+         source: ../../logs
+         target: /logs
+         consistency: consistent
+       - type: bind
+         source: ../../replay
+         target: /etc/gemp-lotr/replay
+         consistency: consistent
+       - type: bind
+         source: ../../logs/nohup.out
+         target: /etc/gemp-lotr/nohup.out
+         consistency: consistent
     networks:
       gemp_net_1:
         ipv4_address: ${APP_IP}
     tty: true
-    command: java -jar -Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector /etc/gemp-lotr/gemp-lotr-async/target/web.jar
+    command: nohup java -jar -Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector /etc/gemp-lotr/gemp-lotr-async/target/web.jar &> /logs/nohup.out &
+
 
   db:
     env_file:


### PR DESCRIPTION
Small but meaningful cleanup for .gitignore
- Organized into sections
- Relevant additions for Java/Maven configurations
- Ignore additional temporary or ephemeral files that are never checked in