### PR TITLE
Hall and game improvements

### DIFF
--- a/gemp-lotr/gemp-lotr-async/src/main/web/hall.html
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/hall.html
@@ -396,6 +396,11 @@
 				<div class="label-column">Keep this window open: </div>
 				<input type="checkbox" id="unranked-keep-open" />
 			</div>
+			
+			<div class="flex-horiz">
+				<div class="label-column">Open this flow by default: </div>
+				<input type="checkbox" id="unranked-default-flow" />
+			</div>
 					
 			<button id="submit-unranked-table-button" class="table-create-button">
 				Create Table

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/gameAnimations.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/gameAnimations.js
@@ -13,9 +13,7 @@ var GameAnimations = Class.extend({
     },
 
     getAnimationLength:function (origValue) {
-        if (this.game.replayMode)
             return origValue * this.replaySpeed;
-        return origValue;
     },
 
     cardActivated:function (element, animate) {

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/gameUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/gameUi.js
@@ -608,6 +608,33 @@ var GempLotrGameUI = Class.extend({
             that.settingsAutoAccept = selected;
             $.cookie("autoAccept", "" + selected, {expires: 365});
         });
+        
+        $("#settingsBox").append("<label for='animation-slider'>Animation Speed</label><br /><div id='animation-slider'></div>");
+        
+        var animSpeed = loadFromCookie("animation-speed", 0);
+        that.animations.replaySpeed = 2 ** (-1 * animSpeed);
+        
+        $("#animation-slider").slider({
+            min:-4,
+            max:4,
+            range: "min",
+            slide: function(event, ui) {
+                let newAnimSpeed = ui.value;
+                saveToCookie("animation-speed", newAnimSpeed);
+                that.animations.replaySpeed = 2 ** (-1 * newAnimSpeed);
+                console.log("set: " + newAnimSpeed);
+                console.log("actual: " + (2 ** (-1 * newAnimSpeed)));
+            },
+            value: animSpeed
+        });
+        
+        // $("#animation-slider").bind("change", function (event) {
+        //     let newAnimSpeed = $("#animation-slider").value;
+        //     $.cookie("animation-speed", "" + newAnimSpeed, {expires: 365});
+        //     that.animations.replaySpeed = 2 ^ newAnimSpeed;
+        //     console.log(newAnimSpeed);
+        //     console.log(2 ^ newAnimSpeed);
+        // });
 
         $("#settingsBox").append("<input id='alwaysDropDown' type='checkbox' value='selected' /><label for='alwaysDropDown'>Always display drop-down in answer selection</label><br />");
 

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/tables/CreateBotTable.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/tables/CreateBotTable.js
@@ -24,8 +24,8 @@ class CreateBotTable {
 		this.formatManager = formatManager;
 		this.deckManager = deckManager;
 		
-		this.playerDeckSelector = new SelectDeck(this.comm, $(div).find(".player-deck"), deckManager)
-		this.botDeckSelector = new SelectDeck(this.comm, $(div).find(".bot-deck"), deckManager)
+		this.playerDeckSelector = new SelectDeck(this.comm, $(div).find(".player-deck"), deckManager, "bot-table");
+		this.botDeckSelector = new SelectDeck(this.comm, $(div).find(".bot-deck"), deckManager, "bot");
 		
 		this.unlockFormatsButton = $("#bot-unlock-format").button().click(() => {
 			that.unlockFormatsButton.hide();

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/tables/CreateLeagueTable.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/tables/CreateLeagueTable.js
@@ -28,7 +28,7 @@ class CreateLeagueTable {
 		this.formatManager = formatManager;
 		this.deckManager = deckManager;
 		
-		this.deckSelector = new SelectDeck(this.comm, $(div).find(".player-deck"), deckManager)
+		this.deckSelector = new SelectDeck(this.comm, $(div).find(".player-deck"), deckManager, "league-table")
 		
 		this.leagueDropdown = $("#league-format");		
 		this.resultDiv = $("#league-result");

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/tables/CreateTable.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/tables/CreateTable.js
@@ -138,6 +138,11 @@ class CreateTable {
 		this.mainSelection.show();
 		
 		this.popup.dialog("open");
+		
+		var unrankedDefaultFlow = loadFromCookie("unranked-table-default-flow", "false");
+		if(unrankedDefaultFlow === "true") {
+			this.createUnrankedButton.click();
+		}
 	}
 	
 	static getResponse(outputControl, callback=null) {

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/tables/DeckManager.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/tables/DeckManager.js
@@ -27,6 +27,7 @@ class DeckManager {
 			}
 			
 			dropdown.val(currentDeck);
+			
 			dropdown.change();
 		});
 	}

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/tables/FormatManager.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/tables/FormatManager.js
@@ -44,7 +44,7 @@ class FormatManager {
 					dropdown.append(options[i]);
 				}
 			}
-			
+
 			dropdown.val(currentFormat);
 			dropdown.change();
 		});
@@ -140,7 +140,21 @@ class FormatManager {
 			});
 	}
 	
-	
+	lookupFormatByName(formatName) {
+		var that = this;
+		
+		var ret = null;
+		
+		Object.keys(this.formats).forEach(function(code, index) {
+			
+			if(that.formats[code].name === formatName) {
+				ret = code;
+				return;
+			}
+		});
+		
+		return ret;
+	}
 	
 	
 	static processFormatsFromJson(json) {
@@ -186,4 +200,6 @@ class FormatManager {
 				}
 			});
 	}
+	
+	
 }

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/tables/SelectDeck.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/tables/SelectDeck.js
@@ -7,21 +7,31 @@ class SelectDeck {
 	playerDeckDropdown = null;
 	libraryDeckDropdown = null;
 	
-	constructor(comm, div, deckManager) {
+	deckCookieName = "last-deck";
+	formatCookieName = "last-format";
+	
+	constructor(comm, div, deckManager, cookie) {
 		this.comm = comm;
 		this.mainDiv = div;
 		this.deckManager = deckManager;
-		
-		//this.mainDiv.tabs();
 		
 		this.formatDropdown = $(div).find(".player-deck-format")
 		this.playerDeckDropdown = $(div).find(".player-deck-dropdown");
 		this.libraryDeckDropdown = $(div).find(".library-deck-dropdown");
 		
+		if(cookie !== undefined) {
+			this.deckCookieName   = cookie + "-last-deck";
+			this.formatCookieName = cookie + "-last-format";
+		}
+		// this.playerDeckDropdown.val(loadFromCookie(this.deckCookieName, ""));
+		// this.formatDropdown.val(loadFromCookie(this.formatCookieName, ""));
+		
 		this.deckManager.registerDropdownUpdate(this.playerDeckDropdown);
 	}
 	
 	getSelectedDeck() {
+		saveToCookie(this.deckCookieName, this.playerDeckDropdown.val());
+		saveToCookie(this.formatCookieName, this.formatDropdown.val());
 		return this.playerDeckDropdown.val();
 	}
 	


### PR DESCRIPTION
- Unranked table creation now stores the last deck, format, and timer used even between refreshes
- In Unranked tables, the form will now automatically select the format targeted by the deck when the deck is selected
- Unranked tables now have a checkbox to make them the default flow, saving a click if that's the view you want to always be presented with
- In-game settings now have a slider option for animation speed, which supports the same 1/16X - 16X speed of replays.  This is stored in a cookie