### PR TITLE
Ready check sound

### DIFF
--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/hallUi.js
@@ -540,6 +540,7 @@ var GempLotrHallUI = Class.extend({
 								that.showDialog("Ready Check", "Ready Check started for the <b>" + queue.getAttribute("queue")
 									+ "</b> tournament.<br><br>To confirm you are present, click the Ready Check button in the Waiting Tables Section within the next "
 									+ queue.getAttribute("readyCheckSecsRemaining") + " seconds.", 230);
+								that.PlaySound("gamestart");
 							}
 							var checkBut = $("<button>READY CHECK - " + queue.getAttribute("readyCheckSecsRemaining") + " s</button>");
 							$(checkBut).button().click((


### PR DESCRIPTION
When last player joins the tournament with ready check and the timer starts, **the sound is played** to notify players.
Only JS change, no need to restart the server.