### PR TITLE
Kings Block Solo Draft + Solo Draft bugfixes

### DIFF
--- a/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
+++ b/gemp-lotr/gemp-lotr-async/src/main/java/com/gempukku/lotro/async/handler/TournamentRequestHandler.java
@@ -107,9 +107,10 @@ public class TournamentRequestHandler extends LotroServerRequestHandler implemen
         Map<String, String> availableSoloDraftFormats = new HashMap<>();
         availableSoloDraftFormats.put("fotr_draft", "Fellowship Block");
         availableSoloDraftFormats.put("ttt_draft", "Towers Block");
+        availableSoloDraftFormats.put("king_draft", "Kings Block");
         availableSoloDraftFormats.put("hobbit_random_draft", "Hobbit");
 
-        List<String> orderedSoloDrafts = List.of("fotr_draft", "ttt_draft", "hobbit_random_draft");
+        List<String> orderedSoloDrafts = List.of("fotr_draft", "ttt_draft", "king_draft", "hobbit_random_draft");
 
         data.constructed = _formatLibrary.getHallFormats().values().stream()
                 .map(constructedFormat -> new JSONDefs.ItemStub(constructedFormat.getCode(), constructedFormat.getName()))

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/draft/fellowshipDraft.json
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/draft/fellowshipDraft.json
@@ -25,97 +25,75 @@
       }
     },
     {
-      "type": "weightedSwitch",
-      "repeat": 10,
+      "type": "filterPick",
+      "repeat": 1,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:FREE_PEOPLE set:1 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:FREE_PEOPLE set:1 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:FREE_PEOPLE set:1 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 5,
+        "filter": "side:FREE_PEOPLE set:1 rarity:R"
       }
-    },{
-      "type": "weightedSwitch",
-      "repeat": 10,
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:FREE_PEOPLE set:2 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:FREE_PEOPLE set:2 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:FREE_PEOPLE set:2 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 8,
+        "filter": "side:FREE_PEOPLE set:1 rarity:U,P"
       }
-    },{
-      "type": "weightedSwitch",
-      "repeat": 10,
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:FREE_PEOPLE set:3 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:FREE_PEOPLE set:3 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:FREE_PEOPLE set:3 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 10,
+        "filter": "side:FREE_PEOPLE set:1 rarity:C"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 5,
+        "filter": "side:FREE_PEOPLE set:2 rarity:R"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
+      "data": {
+        "optionCount": 8,
+        "filter": "side:FREE_PEOPLE set:2 rarity:U,P"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
+      "data": {
+        "optionCount": 10,
+        "filter": "side:FREE_PEOPLE set:2 rarity:C"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 5,
+        "filter": "side:FREE_PEOPLE set:3 rarity:R"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
+      "data": {
+        "optionCount": 8,
+        "filter": "side:FREE_PEOPLE set:3 rarity:U,P"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
+      "data": {
+        "optionCount": 10,
+        "filter": "side:FREE_PEOPLE set:3 rarity:C"
       }
     },
     {
@@ -127,97 +105,75 @@
       }
     },
     {
-      "type": "weightedSwitch",
-      "repeat": 10,
+      "type": "filterPick",
+      "repeat": 1,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:SHADOW set:1 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:SHADOW set:1 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:SHADOW set:1 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 5,
+        "filter": "side:SHADOW set:1 rarity:R"
       }
-    },{
-      "type": "weightedSwitch",
-      "repeat": 10,
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:SHADOW set:2 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:SHADOW set:2 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:SHADOW set:2 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 8,
+        "filter": "side:SHADOW set:1 rarity:U,P"
       }
-    },{
-      "type": "weightedSwitch",
-      "repeat": 10,
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:SHADOW set:3 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:SHADOW set:3 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:SHADOW set:3 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 10,
+        "filter": "side:SHADOW set:1 rarity:C"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 5,
+        "filter": "side:SHADOW set:2 rarity:R"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
+      "data": {
+        "optionCount": 8,
+        "filter": "side:SHADOW set:2 rarity:U,P"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
+      "data": {
+        "optionCount": 10,
+        "filter": "side:SHADOW set:2 rarity:C"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 5,
+        "filter": "side:SHADOW set:3 rarity:R"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
+      "data": {
+        "optionCount": 8,
+        "filter": "side:SHADOW set:3 rarity:U,P"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
+      "data": {
+        "optionCount": 10,
+        "filter": "side:SHADOW set:3 rarity:C"
       }
     },
     {

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/draft/kingDraft.json
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/draft/kingDraft.json
@@ -1,0 +1,308 @@
+{
+  "code": "king_draft",
+  "format": "limited_king",
+  "startingPool": {
+    "type": "boosterDraftRun",
+    "data": {
+      "runLength": 14,
+      "coreCards": ["7_1","7_317", "7_319", "7_212"],
+      "freePeoplesRuns": [
+        ["8_39", "7_108", "7_81", "7_121", "7_81", "8_40", "8_39",
+          "7_124", "7_98", "7_90", "7_83", "7_83", "7_90", "7_98", "7_110",
+          "8_87", "7_253", "7_225", "7_259", "7_225", "7_253", "8_87",
+          "7_246", "7_240", "7_254", "7_243", "7_243", "7_254", "7_248", "7_246"],
+        ["7_36", "7_31", "7_40", "7_52", "7_40", "7_31", "7_36",
+          "7_26", "7_20", "8_13", "7_20", "7_26",
+          "7_6", "7_11", "8_1", "7_11", "7_6",
+          "7_72", "7_78", "8_29", "7_78", "7_72",
+          "7_320", "7_322", "10_112", "7_323", "7_320", "10_112", "7_322", "7_323"]
+      ],
+      "shadowRuns": [
+        ["10_54", "10_57", "10_56", "10_55", "7_186", "7_186", "10_55", "10_56", "10_57", "10_54",
+          "7_138", "7_132", "7_131", "7_172", "7_173", "7_173", "7_172", "7_131", "7_132", "7_138",
+          "7_288", "7_289", "7_291", "7_285", "7_292", "7_292", "7_285", "7_291", "7_289", "7_288",
+          "8_79", "7_217", "7_196", "7_201", "7_200", "7_200", "7_201", "7_196", "7_218", "7_214",
+          "10_49", "7_137", "7_136", "7_160", "7_155", "7_155", "7_160", "7_136", "7_137", "10_49",
+          "10_84", "10_81", "10_82", "10_83", "10_102", "10_102", "10_83", "10_82", "10_81", "10_84"]
+      ]
+    }
+  },
+  "choices": [
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 5,
+        "filter": "side:FREE_PEOPLE set:7,8,10 rarity:R"
+      }
+    },
+    {
+      "type": "weightedSwitch",
+      "repeat": 10,
+      "data": {
+        "switchResult": [
+          {
+            "weight": 0.1,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 5,
+              "filter": "side:FREE_PEOPLE set:7 rarity:R"
+            }
+          },
+          {
+            "weight": 0.3,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 8,
+              "filter": "side:FREE_PEOPLE set:7 rarity:U,P"
+            }
+          },
+          {
+            "weight": 0.6,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 10,
+              "filter": "side:FREE_PEOPLE set:7 rarity:C"
+            }
+          }
+        ]
+      }
+    },{
+      "type": "weightedSwitch",
+      "repeat": 10,
+      "data": {
+        "switchResult": [
+          {
+            "weight": 0.1,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 5,
+              "filter": "side:FREE_PEOPLE set:8 rarity:R"
+            }
+          },
+          {
+            "weight": 0.3,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 8,
+              "filter": "side:FREE_PEOPLE set:8 rarity:U,P"
+            }
+          },
+          {
+            "weight": 0.6,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 10,
+              "filter": "side:FREE_PEOPLE set:8 rarity:C"
+            }
+          }
+        ]
+      }
+    },{
+      "type": "weightedSwitch",
+      "repeat": 10,
+      "data": {
+        "switchResult": [
+          {
+            "weight": 0.1,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 5,
+              "filter": "side:FREE_PEOPLE set:10 rarity:R"
+            }
+          },
+          {
+            "weight": 0.3,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 8,
+              "filter": "side:FREE_PEOPLE set:10 rarity:U,P"
+            }
+          },
+          {
+            "weight": 0.6,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 10,
+              "filter": "side:FREE_PEOPLE set:10 rarity:C"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 5,
+        "filter": "side:SHADOW set:7,8,10 rarity:R"
+      }
+    },
+    {
+      "type": "weightedSwitch",
+      "repeat": 10,
+      "data": {
+        "switchResult": [
+          {
+            "weight": 0.1,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 5,
+              "filter": "side:SHADOW set:7 rarity:R"
+            }
+          },
+          {
+            "weight": 0.3,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 8,
+              "filter": "side:SHADOW set:7 rarity:U,P"
+            }
+          },
+          {
+            "weight": 0.6,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 10,
+              "filter": "side:SHADOW set:7 rarity:C"
+            }
+          }
+        ]
+      }
+    },{
+      "type": "weightedSwitch",
+      "repeat": 10,
+      "data": {
+        "switchResult": [
+          {
+            "weight": 0.1,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 5,
+              "filter": "side:SHADOW set:8 rarity:R"
+            }
+          },
+          {
+            "weight": 0.3,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 8,
+              "filter": "side:SHADOW set:8 rarity:U,P"
+            }
+          },
+          {
+            "weight": 0.6,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 10,
+              "filter": "side:SHADOW set:8 rarity:C"
+            }
+          }
+        ]
+      }
+    },{
+      "type": "weightedSwitch",
+      "repeat": 10,
+      "data": {
+        "switchResult": [
+          {
+            "weight": 0.1,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 5,
+              "filter": "side:SHADOW set:10 rarity:R"
+            }
+          },
+          {
+            "weight": 0.3,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 8,
+              "filter": "side:SHADOW set:10 rarity:U,P"
+            }
+          },
+          {
+            "weight": 0.6,
+            "type": "filterPick",
+            "data": {
+              "optionCount": 10,
+              "filter": "side:SHADOW set:10 rarity:C"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 3,
+        "filter": "cardType:SITE set:7,8,10 siteNumber:1"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 3,
+        "filter": "cardType:SITE set:7,8,10 siteNumber:2"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 3,
+        "filter": "cardType:SITE set:7,8,10 siteNumber:3"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 3,
+        "filter": "cardType:SITE set:7,8,10 siteNumber:4"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 3,
+        "filter": "cardType:SITE set:7,8,10 siteNumber:5"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 3,
+        "filter": "cardType:SITE set:7,8,10 siteNumber:6"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 3,
+        "filter": "cardType:SITE set:7,8,10 siteNumber:7"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 3,
+        "filter": "cardType:SITE set:7,8,10 siteNumber:8"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 3,
+        "filter": "cardType:SITE set:7,8,10 siteNumber:9"
+      }
+    }
+  ]
+}

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/draft/kingDraft.json
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/draft/kingDraft.json
@@ -37,97 +37,75 @@
       }
     },
     {
-      "type": "weightedSwitch",
-      "repeat": 10,
+      "type": "filterPick",
+      "repeat": 1,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:FREE_PEOPLE set:7 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:FREE_PEOPLE set:7 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:FREE_PEOPLE set:7 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 5,
+        "filter": "side:FREE_PEOPLE set:7 rarity:R"
       }
-    },{
-      "type": "weightedSwitch",
-      "repeat": 10,
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:FREE_PEOPLE set:8 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:FREE_PEOPLE set:8 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:FREE_PEOPLE set:8 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 8,
+        "filter": "side:FREE_PEOPLE set:7 rarity:U,P"
       }
-    },{
-      "type": "weightedSwitch",
-      "repeat": 10,
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:FREE_PEOPLE set:10 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:FREE_PEOPLE set:10 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:FREE_PEOPLE set:10 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 10,
+        "filter": "side:FREE_PEOPLE set:7 rarity:C"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 5,
+        "filter": "side:FREE_PEOPLE set:8 rarity:R"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
+      "data": {
+        "optionCount": 8,
+        "filter": "side:FREE_PEOPLE set:8 rarity:U,P"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
+      "data": {
+        "optionCount": 10,
+        "filter": "side:FREE_PEOPLE set:8 rarity:C"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 5,
+        "filter": "side:FREE_PEOPLE set:10 rarity:R"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
+      "data": {
+        "optionCount": 8,
+        "filter": "side:FREE_PEOPLE set:10 rarity:U,P"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
+      "data": {
+        "optionCount": 10,
+        "filter": "side:FREE_PEOPLE set:10 rarity:C"
       }
     },
     {
@@ -139,97 +117,75 @@
       }
     },
     {
-      "type": "weightedSwitch",
-      "repeat": 10,
+      "type": "filterPick",
+      "repeat": 1,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:SHADOW set:7 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:SHADOW set:7 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:SHADOW set:7 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 5,
+        "filter": "side:SHADOW set:7 rarity:R"
       }
-    },{
-      "type": "weightedSwitch",
-      "repeat": 10,
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:SHADOW set:8 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:SHADOW set:8 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:SHADOW set:8 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 8,
+        "filter": "side:SHADOW set:7 rarity:U,P"
       }
-    },{
-      "type": "weightedSwitch",
-      "repeat": 10,
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:SHADOW set:10 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:SHADOW set:10 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:SHADOW set:10 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 10,
+        "filter": "side:SHADOW set:7 rarity:C"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 5,
+        "filter": "side:SHADOW set:8 rarity:R"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
+      "data": {
+        "optionCount": 8,
+        "filter": "side:SHADOW set:8 rarity:U,P"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
+      "data": {
+        "optionCount": 10,
+        "filter": "side:SHADOW set:8 rarity:C"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 5,
+        "filter": "side:SHADOW set:10 rarity:R"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
+      "data": {
+        "optionCount": 8,
+        "filter": "side:SHADOW set:10 rarity:U,P"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
+      "data": {
+        "optionCount": 10,
+        "filter": "side:SHADOW set:10 rarity:C"
       }
     },
     {

--- a/gemp-lotr/gemp-lotr-cards/src/main/resources/draft/twoTowersDraft.json
+++ b/gemp-lotr/gemp-lotr-cards/src/main/resources/draft/twoTowersDraft.json
@@ -25,97 +25,75 @@
       }
     },
     {
-      "type": "weightedSwitch",
-      "repeat": 10,
+      "type": "filterPick",
+      "repeat": 1,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:FREE_PEOPLE set:4 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:FREE_PEOPLE set:4 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:FREE_PEOPLE set:4 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 5,
+        "filter": "side:FREE_PEOPLE set:4 rarity:R"
       }
-    },{
-      "type": "weightedSwitch",
-      "repeat": 10,
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:FREE_PEOPLE set:5 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:FREE_PEOPLE set:5 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:FREE_PEOPLE set:5 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 8,
+        "filter": "side:FREE_PEOPLE set:4 rarity:U,P"
       }
-    },{
-      "type": "weightedSwitch",
-      "repeat": 10,
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:FREE_PEOPLE set:6 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:FREE_PEOPLE set:6 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:FREE_PEOPLE set:6 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 10,
+        "filter": "side:FREE_PEOPLE set:4 rarity:C"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 5,
+        "filter": "side:FREE_PEOPLE set:5 rarity:R"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
+      "data": {
+        "optionCount": 8,
+        "filter": "side:FREE_PEOPLE set:5 rarity:U,P"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
+      "data": {
+        "optionCount": 10,
+        "filter": "side:FREE_PEOPLE set:5 rarity:C"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 5,
+        "filter": "side:FREE_PEOPLE set:6 rarity:R"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
+      "data": {
+        "optionCount": 8,
+        "filter": "side:FREE_PEOPLE set:6 rarity:U,P"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
+      "data": {
+        "optionCount": 10,
+        "filter": "side:FREE_PEOPLE set:6 rarity:C"
       }
     },
     {
@@ -127,97 +105,75 @@
       }
     },
     {
-      "type": "weightedSwitch",
-      "repeat": 10,
+      "type": "filterPick",
+      "repeat": 1,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:SHADOW set:4 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:SHADOW set:4 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:SHADOW set:4 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 5,
+        "filter": "side:SHADOW set:4 rarity:R"
       }
-    },{
-      "type": "weightedSwitch",
-      "repeat": 10,
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:SHADOW set:5 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:SHADOW set:5 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:SHADOW set:5 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 8,
+        "filter": "side:SHADOW set:4 rarity:U,P"
       }
-    },{
-      "type": "weightedSwitch",
-      "repeat": 10,
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
       "data": {
-        "switchResult": [
-          {
-            "weight": 0.1,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 5,
-              "filter": "side:SHADOW set:6 rarity:R"
-            }
-          },
-          {
-            "weight": 0.3,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 8,
-              "filter": "side:SHADOW set:6 rarity:U,P"
-            }
-          },
-          {
-            "weight": 0.6,
-            "type": "filterPick",
-            "data": {
-              "optionCount": 10,
-              "filter": "side:SHADOW set:6 rarity:C"
-            }
-          }
-        ]
+        "optionCount": 10,
+        "filter": "side:SHADOW set:4 rarity:C"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 5,
+        "filter": "side:SHADOW set:5 rarity:R"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
+      "data": {
+        "optionCount": 8,
+        "filter": "side:SHADOW set:5 rarity:U,P"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
+      "data": {
+        "optionCount": 10,
+        "filter": "side:SHADOW set:5 rarity:C"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 1,
+      "data": {
+        "optionCount": 5,
+        "filter": "side:SHADOW set:6 rarity:R"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 3,
+      "data": {
+        "optionCount": 8,
+        "filter": "side:SHADOW set:6 rarity:U,P"
+      }
+    },
+    {
+      "type": "filterPick",
+      "repeat": 6,
+      "data": {
+        "optionCount": 10,
+        "filter": "side:SHADOW set:6 rarity:C"
       }
     },
     {

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/draft2/builder/DraftChoiceBuilder.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/draft2/builder/DraftChoiceBuilder.java
@@ -55,6 +55,32 @@ public class DraftChoiceBuilder {
 
         final List<CardCollection.Item> possibleCards = _sortAndFilterCards.process(filter, items, _cardLibrary, _formatLibrary);
 
+        // Possible cards can contain duplicates, same name from different sets are considered legal by the filter
+        // Different art would not be a problem, but it multiplies the odds of seeing the card
+        boolean filterContainsSet = filter.contains("set:");
+        List<String> sets = new ArrayList<>();
+        if (filterContainsSet) {
+            String[] filterParts = filter.split(" ");
+            for (String part : filterParts) {
+                if (part.startsWith("set:")) {
+                    String setPart = part.substring(4);
+                    String[] setNumbers = setPart.split(",");
+                    Collections.addAll(sets, setNumbers);
+                }
+            }
+        }
+        possibleCards.removeIf(item -> {
+            if (!filterContainsSet) {
+                return false;
+            }
+            for (String set : sets) {
+                if (item.getBlueprintId().startsWith(set + "_")) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
         return new DraftChoiceDefinition() {
             @Override
             public Iterable<SoloDraft.DraftChoice> getDraftChoice(long seed, int stage, DefaultCardCollection draftPool) {

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/draft2/builder/StartingPoolBuilder.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/draft2/builder/StartingPoolBuilder.java
@@ -46,25 +46,38 @@ public class StartingPoolBuilder {
         final JSONArray coreCards = (JSONArray) boosterDraftRun.get("coreCards");
         final JSONArray freePeoplesRuns = (JSONArray) boosterDraftRun.get("freePeoplesRuns");
         final JSONArray shadowRuns = (JSONArray) boosterDraftRun.get("shadowRuns");
+        final int fpRunLength = runLength / freePeoplesRuns.size();
+        final int shadowRunLength = runLength / shadowRuns.size();
 
         return seed -> {
             Random rnd = new Random(seed);
-            List<String> freePeoplesRun = (List<String>) freePeoplesRuns.get(rnd.nextInt(freePeoplesRuns.size()));
-            List<String> shadowRun = (List<String>) shadowRuns.get(rnd.nextInt(shadowRuns.size()));
-
-            int freePeopleLength = freePeoplesRun.size();
-            int freePeopleStart = rnd.nextInt(freePeopleLength);
-
-            int shadowLength = shadowRun.size();
-            int shadowStart = rnd.nextInt(shadowLength);
-
-            Iterable<String> freePeopleIterable = getCyclingIterable(freePeoplesRun, freePeopleStart, runLength);
-            Iterable<String> shadowIterable = getCyclingIterable(shadowRun, shadowStart, runLength);
 
             final DefaultCardCollection startingCollection = new DefaultCardCollection();
 
-            for (String card : Iterables.concat((List<String>) coreCards, freePeopleIterable, shadowIterable))
+            for (String card : (List<String>) coreCards)
                 startingCollection.addItem(card, 1);
+
+            for (Object run : freePeoplesRuns) {
+                List<String> freePeoplesRun = (List<String>) run;
+
+                int freePeopleLength = freePeoplesRun.size();
+                int freePeopleStart = rnd.nextInt(freePeopleLength);
+
+                Iterable<String> freePeopleIterable = getCyclingIterable(freePeoplesRun, freePeopleStart, fpRunLength);
+                for (String card : freePeopleIterable)
+                    startingCollection.addItem(card, 1);
+            }
+
+            for (Object run : shadowRuns) {
+                List<String> shadowRun = (List<String>) run;
+
+                int shadowLength = shadowRun.size();
+                int shadowStart = rnd.nextInt(shadowLength);
+
+                Iterable<String> shadowIterable = getCyclingIterable(shadowRun, shadowStart, shadowRunLength);
+                for (String card : shadowIterable)
+                    startingCollection.addItem(card, 1);
+            }
 
             return startingCollection;
         };


### PR DESCRIPTION
### Kings Block Solo Draft

- available for leagues, scheduled tournaments and ad-hoc tournaments created by players
- traditional solo draft structure: core cards, draft pack, FP filter picks, shadow filter picks, site picking
- starting cards are designed by me - just threw some stuff together to have a starting point for future improvements, if needed
- core cards: Frodo, Hope of Free Peoples; The One Ring, The Ruling Ring; Hobbit Sword; Ulaire Enquea, Faster Than Winds
- FP wheel 1: half rohan, half gondor
- FP wheel 2: gandalf, legolas, gimli, smeagol, merry + pippin
- shadow wheel: cirith ungol morcs, raider threats, sauron orc threats, nazgul, raider wounding, sauron uruks

### Bugfixes

- solo draft now properly uses all defined wheels instead of choosing one randomly (all solo draft formats)
- solo draft no longer offers multiple prints of legal cards, multiplying the odds of them appearing (all solo draft formats)
- removes probabilistic rarity distribution for fotr, ttt and kings solo drafts (solves #1043 )

### Server restart

Needed for bugfixes and making kings draft available for player-made tournaments. For potential kings draft league json reload should be enough.