### PR TITLE
'Product: Special' filter in deck-builder

### DIFF
--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/cards/CardFilter.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/cards/CardFilter.js
@@ -333,6 +333,7 @@ var CardFilter = Class.extend({
 			+ "<option value='foil'>Foils</option>"
 			+ "<option value='nonFoil'>Non-foils</option>"
 			+ "<option value='tengwar'>Tengwar</option>"
+			+ "<option value='special'>Special</option>"
 			+ "</select>");
 		
 		this.sortLabel = $("<label for='sortSelect' class='filterLabel'>Sort by:</label>");

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/cards/CardFilter.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/cards/CardFilter.js
@@ -3,6 +3,7 @@ var CardFilter = Class.extend({
 	addCardFunc: null,
 	finishCollectionFunc: null,
 	getCollectionFunc: null,
+	getCardsInDeckFunc: null,
 
 	collectionType: null,
 
@@ -79,13 +80,14 @@ var CardFilter = Class.extend({
 	siteOverride: false,
 	
 
-	init: function (pageElem, getCollectionFunc, clearCollectionFunc, addCardFunc, finishCollectionFunc) {
+	init: function (pageElem, getCollectionFunc, clearCollectionFunc, addCardFunc, finishCollectionFunc, getCardsInDeckFunc) {
 		this.initialStartup = false;
 		
 		this.getCollectionFunc = getCollectionFunc;
 		this.clearCollectionFunc = clearCollectionFunc;
 		this.addCardFunc = addCardFunc;
 		this.finishCollectionFunc = finishCollectionFunc;
+		this.getCardsInDeckFunc = getCardsInDeckFunc;
 
 		this.filter = "";
 
@@ -334,6 +336,7 @@ var CardFilter = Class.extend({
 			+ "<option value='nonFoil'>Non-foils</option>"
 			+ "<option value='tengwar'>Tengwar</option>"
 			+ "<option value='special'>Special</option>"
+			+ "<option value='specialForDeck'>Special in Deck</option>"
 			+ "</select>");
 		
 		this.sortLabel = $("<label for='sortSelect' class='filterLabel'>Sort by:</label>");
@@ -972,11 +975,17 @@ var CardFilter = Class.extend({
 			siteOverrideParam = " siteOverride:true";
 		}
 
+        var blueprints = "";
+        if (product == " product:specialForDeck") {
+            blueprints = " blueprints:" + this.getCardsInDeckFunc();
+        }
+
 		var filterString = side + format + block + set + cardType + rarity + sort + product + culture
 				+ name + gametext
 				+ keyword + phase + race + itemClass
 				+ twilight + strength + vitality + resistance + siteNumber + signet
 				+ siteOverrideParam
+				+ blueprints
 				+ " " + predefFilter;
 
 		console.log("Regenerating filter: " + filterString);

--- a/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/deckBuildingUi.js
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/js/gemp-022/deckBuildingUi.js
@@ -100,7 +100,10 @@ var GempLotrDeckBuildingUI = Class.extend({
 				},
 				function () {
 					that.finishCollection();
-				});
+				},
+                function () {
+                    return that.getCardsInDeck();
+                });
 		
 		//this.cardFilter.setFilterOverride(this.defaultSelection);
 
@@ -1342,29 +1345,22 @@ var GempLotrDeckBuildingUI = Class.extend({
 		this.deckModified(false);
 	},
 
+    getCardsInDeck:function () {
+        var cards = [];
+        $(".cardInDeck").each(
+            function () {
+                var cardData = $(this).data("card").bareBlueprint;
+                cards.push(cardData);
+            });
+        return cards;
+    },
+
 	setupDeck:function (xml, deckName) {
 		var root = xml.documentElement;
 		if (root.tagName == "deck") {
 			this.clearDeck();
 			this.deckName = deckName;
 			$("#editingDeck").text(deckName);
-			
-			var targetFormat = root.getElementsByTagName("targetFormat");
-			if (targetFormat.length > 0)
-			{
-				var formatCode = targetFormat[0].getAttribute("formatCode");
-				var leagueCode = targetFormat[0].getAttribute("leagueCode");
-
-				// If the deck is associated with an active RTMD league,
-				// select that league entry in the dropdown instead of the
-				// underlying format.
-				if (leagueCode && this.rtmdLeagues && this.rtmdLeagues[leagueCode]) {
-					this.formatSelect.val(leagueCode);
-				} else {
-					this.formatSelect.val(formatCode);
-				}
-				this.formatSelect.change();
-			}
 			
 			var notes = root.getElementsByTagName("notes");
 			this.notes = notes[0].innerHTML;
@@ -1388,6 +1384,23 @@ var GempLotrDeckBuildingUI = Class.extend({
 			var cards = root.getElementsByTagName("card");
 			for (var i = 0; i < cards.length; i++)
 				this.addCardToDeck(cards[i].getAttribute("blueprintId"), cards[i].getAttribute("side"));
+
+			var targetFormat = root.getElementsByTagName("targetFormat");
+			if (targetFormat.length > 0)
+			{
+				var formatCode = targetFormat[0].getAttribute("formatCode");
+				var leagueCode = targetFormat[0].getAttribute("leagueCode");
+
+				// If the deck is associated with an active RTMD league,
+				// select that league entry in the dropdown instead of the
+				// underlying format.
+				if (leagueCode && this.rtmdLeagues && this.rtmdLeagues[leagueCode]) {
+					this.formatSelect.val(leagueCode);
+				} else {
+					this.formatSelect.val(formatCode);
+				}
+				this.formatSelect.change();
+			}
 
 			this.layoutUI(false);
 

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/game/SortAndFilterCards.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/game/SortAndFilterCards.java
@@ -55,6 +55,16 @@ public class SortAndFilterCards {
         var canStartWithRing = getBoolean(params.get("canstartwithring"));
         var siteOverride = Boolean.TRUE.equals(getBoolean(params.get("siteoverride")));
 
+        var blueprints = params.getOrDefault("blueprints", new ArrayList<>());
+        var okNames = new ArrayList<String>();
+        for (String blueprintId : blueprints) {
+            try {
+                okNames.add(cardLibrary.getLotroCardBlueprint(blueprintId).getFullName());
+            } catch (CardNotFoundException ignored) {
+
+            }
+        }
+
         List<T> result = new ArrayList<>();
         var cardBPCache = new HashMap<String, LotroCardBlueprint>();
         var setDefs = cardLibrary.getSetDefinitions();
@@ -66,7 +76,7 @@ public class SortAndFilterCards {
             String strippedId = BlueprintUtils.stripModifiers(blueprintId);
 
             if (isPack(blueprintId)) {
-                if (product == null || product.equals("pack")) {
+                if (product == null || product.equalsIgnoreCase("pack") || product.equalsIgnoreCase("special") || product.equalsIgnoreCase("specialfordeck")) {
                     result.add(item);
                 }
                 continue;
@@ -120,6 +130,14 @@ public class SortAndFilterCards {
                         continue;
                     }
                     case "special" -> {
+                        if (cardLibrary.getBaseCards().containsKey(blueprintId))
+                            continue;
+                        if (cardLibrary.getBaseCards().containsKey(strippedId) && !blueprintId.contains("T"))
+                            continue;
+                    }
+                    case "specialfordeck" -> {
+                        if (!okNames.contains(card.getFullName()))
+                            continue;
                         if (cardLibrary.getBaseCards().containsKey(blueprintId))
                             continue;
                         if (cardLibrary.getBaseCards().containsKey(strippedId) && !blueprintId.contains("T"))

--- a/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/game/SortAndFilterCards.java
+++ b/gemp-lotr/gemp-lotr-server/src/main/java/com/gempukku/lotro/game/SortAndFilterCards.java
@@ -119,6 +119,12 @@ public class SortAndFilterCards {
                     case "pack" -> {
                         continue;
                     }
+                    case "special" -> {
+                        if (cardLibrary.getBaseCards().containsKey(blueprintId))
+                            continue;
+                        if (cardLibrary.getBaseCards().containsKey(strippedId) && !blueprintId.contains("T"))
+                            continue;
+                    }
                 }
             }
 


### PR DESCRIPTION
New filter option - displays cards that are not part of the default 'all cards' collections.

<img width="563" height="901" alt="image" src="https://github.com/user-attachments/assets/df1e3dc1-7d6b-4405-acc4-19a71dc884e3" />
